### PR TITLE
Factor out helper functions for other libraries to encode and decode sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ For a full "start to finish" example without having to generate keys and setup a
 If you need to encode or decode a session in related systems (like say `fastify-websockets`, which doesn't use normal Fastify `Request` objects), you can use `fastify-secure-session`'s decorators to encode and decode sessions yourself. This is less than ideal as this library's cookie setting code is battle tested by the community, but the option is there if you need it.
 
 ```js
+fastify.createSecureSession({foo: 'bar'})
+// => Session returns a session object for manipulating with .get and .set to then be encoded with encodeSecureSession
+
 fastify.encodeSecureSession(request.session)
 // => "abcdefg" returns the signed and encrypted cookie string, suitable for passing to a Set-Cookie header
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ time the older session is decoded will be a little more expensive though.
 
 For a full "start to finish" example without having to generate keys and setup a server file, see the *second* test case in the test file at `/test/key-rotation.js` in this repo.
 
+## Integrating with other libraries
+
+If you need to encode or decode a session in related systems (like say `fastify-websockets`, which doesn't use normal Fastify `Request` objects), you can use `fastify-secure-session`'s decorators to encode and decode sessions yourself. This is less than ideal as this library's cookie setting code is battle tested by the community, but the option is there if you need it.
+
+```js
+fastify.encodeSecureSession(request.session)
+// => "abcdefg" returns the signed and encrypted cookie string, suitable for passing to a Set-Cookie header
+
+fastify.decodeSecureSession(request.cookies['session'])
+// => Session | null  returns a session object which you can use to .get values from if decoding is successful, and null otherwise
+```
+
 ## TODO
 
 * [ ] add an option to just sign, and do not encrypt

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 import { CookieSerializeOptions } from "fastify-cookie";
 import { FastifyPlugin, FastifyLoggerInstance } from "fastify";
 
-export class Session {
+export interface Session {
   changed: boolean;
   deleted: boolean;
   get(key: string): any;
@@ -23,6 +23,7 @@ export default SecureSessionPlugin;
 
 declare module "fastify" {
   interface FastifyInstance {
+    createSecureSession(data?: Record<string, any>): Session
     decodeSecureSession(cookie: string, log?: FastifyLoggerInstance): Session | null
     encodeSecureSession(session: Session): string
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import { CookieSerializeOptions } from "fastify-cookie";
-import { FastifyPlugin } from "fastify";
+import { FastifyPlugin, FastifyLoggerInstance } from "fastify";
 
-export interface Session {
+export class Session {
   changed: boolean;
   deleted: boolean;
   get(key: string): any;
@@ -22,6 +22,11 @@ declare const SecureSessionPlugin: FastifyPlugin<SecureSessionPluginOptions>;
 export default SecureSessionPlugin;
 
 declare module "fastify" {
+  interface FastifyInstance {
+    decodeSecureSession(cookie: string, log?: FastifyLoggerInstance): Session | null
+    encodeSecureSession(session: Session): string
+  }
+
   interface FastifyRequest {
     session: Session;
   }

--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ module.exports = fp(function (fastify, options, next) {
     return session
   })
 
+  fastify.decorate('createSecureSession', (data) => new Session(data))
+
   fastify.decorate('encodeSecureSession', (session) => {
     const nonce = genNonce()
     const msg = Buffer.from(JSON.stringify(session[kObj]))
@@ -197,8 +199,6 @@ class Session {
     this.deleted = true
   }
 }
-
-module.exports.Session = Session
 
 function genNonce () {
   var buf = Buffer.allocUnsafe(sodium.crypto_secretbox_NONCEBYTES)

--- a/index.js
+++ b/index.js
@@ -65,6 +65,71 @@ module.exports = fp(function (fastify, options, next) {
   // TODO verify if it helps the perf
   fastify.decorateRequest('session', null)
 
+  fastify.decorate('decodeSecureSession', (cookie, log = fastify.log) => {
+    if (cookie === undefined) {
+      // there is no cookie
+      log.debug('fastify-secure-session: there is no cookie, creating an empty session')
+      return null
+    }
+
+    // do not use destructuring or it will deopt
+    const split = cookie.split(';')
+    const cyphertextB64 = split[0]
+    const nonceB64 = split[1]
+
+    if (split.length <= 1) {
+      // the cookie is malformed
+      log.debug('fastify-secure-session: the cookie is malformed, creating an empty session')
+      return null
+    }
+
+    const cipher = Buffer.from(cyphertextB64, 'base64')
+    const nonce = Buffer.from(nonceB64, 'base64')
+
+    if (cipher.length < sodium.crypto_secretbox_MACBYTES) {
+      // not long enough
+      log.debug('fastify-secure-session: the cipher is not long enough, creating an empty session')
+      return null
+    }
+
+    if (nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
+      // the length is not correct
+      log.debug('fastify-secure-session: the nonce does not have the required length, creating an empty session')
+      return null
+    }
+
+    const msg = Buffer.allocUnsafe(cipher.length - sodium.crypto_secretbox_MACBYTES)
+
+    let signingKeyRotated = false
+    const decodeSuccess = key.some((k, i) => {
+      const decoded = sodium.crypto_secretbox_open_easy(msg, cipher, nonce, k)
+
+      signingKeyRotated = decoded && i > 0
+
+      return decoded
+    })
+
+    if (!decodeSuccess) {
+      // unable to decrypt
+      log.debug('fastify-secure-session: unable to decrypt, creating an empty session')
+      return null
+    }
+
+    const session = new Session(JSON.parse(msg))
+    session.changed = signingKeyRotated
+    return session
+  })
+
+  fastify.decorate('encodeSecureSession', (session) => {
+    const nonce = genNonce()
+    const msg = Buffer.from(JSON.stringify(session[kObj]))
+
+    const cipher = Buffer.allocUnsafe(msg.length + sodium.crypto_secretbox_MACBYTES)
+    sodium.crypto_secretbox_easy(cipher, msg, nonce, key[0])
+
+    return cipher.toString('base64') + ';' + nonce.toString('base64')
+  })
+
   fastify
     .register(require('fastify-cookie'))
     .register(fp(addHooks))
@@ -74,77 +139,15 @@ module.exports = fp(function (fastify, options, next) {
   function addHooks (fastify, options, next) {
     // the hooks must be registered after fastify-cookie hooks
 
-    fastify.addHook('onRequest', function decodeSession (request, reply, next) {
+    fastify.addHook('onRequest', (request, reply, next) => {
       const cookie = request.cookies[cookieName]
-      if (cookie === undefined) {
-        // there is no cookie
-        request.log.debug('fastify-secure-session: there is no cookie, creating an empty session')
-        request.session = new Session({})
-        next()
-        return
-      }
-
-      // do not use destructuring or it will deopt
-      const split = cookie.split(';')
-      const cyphertextB64 = split[0]
-      const nonceB64 = split[1]
-
-      if (split.length <= 1) {
-        // the cookie is malformed
-        request.log.debug('fastify-secure-session: the cookie is malformed, creating an empty session')
-        request.session = new Session({})
-        next()
-        return
-      }
-
-      const cipher = Buffer.from(cyphertextB64, 'base64')
-      const nonce = Buffer.from(nonceB64, 'base64')
-
-      if (cipher.length < sodium.crypto_secretbox_MACBYTES) {
-        // not long enough
-        request.log.debug('fastify-secure-session: the cipher is not long enough, creating an empty session')
-        request.session = new Session({})
-        next()
-        return
-      }
-
-      if (nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
-        // the length is not correct
-        request.log.debug('fastify-secure-session: the nonce does not have the required length, creating an empty session')
-        request.session = new Session({})
-        next()
-        return
-      }
-
-      const msg = Buffer.allocUnsafe(cipher.length - sodium.crypto_secretbox_MACBYTES)
-
-      let signingKeyRotated = false
-      const decodeSuccess = key.some((k, i) => {
-        const decoded = sodium.crypto_secretbox_open_easy(msg, cipher, nonce, k)
-
-        signingKeyRotated = decoded && i > 0
-
-        return decoded
-      })
-
-      if (!decodeSuccess) {
-        // unable to decrypt
-        request.log.debug('fastify-secure-session: unable to decrypt, creating an empty session')
-        request.session = new Session({})
-        next()
-        return
-      }
-
-      request.session = new Session(JSON.parse(msg))
-
-      if (signingKeyRotated) {
-        request.session.changed = true
-      }
+      const result = fastify.decodeSecureSession(cookie, request.log)
+      request.session = result || new Session({})
 
       next()
     })
 
-    fastify.addHook('onSend', function encodeSession (request, reply, payload, next) {
+    fastify.addHook('onSend', (request, reply, payload, next) => {
       const session = request.session
 
       if (!session || !session.changed) {
@@ -161,13 +164,8 @@ module.exports = fp(function (fastify, options, next) {
       }
 
       request.log.debug('fastify-secure-session: setting session')
-      const nonce = genNonce()
-      const msg = Buffer.from(JSON.stringify(session[kObj]))
+      reply.setCookie(cookieName, fastify.encodeSecureSession(session), cookieOptions)
 
-      const cipher = Buffer.allocUnsafe(msg.length + sodium.crypto_secretbox_MACBYTES)
-      sodium.crypto_secretbox_easy(cipher, msg, nonce, key[0])
-
-      reply.setCookie(cookieName, cipher.toString('base64') + ';' + nonce.toString('base64'), cookieOptions)
       next()
     })
 
@@ -199,6 +197,8 @@ class Session {
     this.deleted = true
   }
 }
+
+module.exports.Session = Session
 
 function genNonce () {
   var buf = Buffer.allocUnsafe(sodium.crypto_secretbox_NONCEBYTES)

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -24,4 +24,8 @@ app.get("/not-websockets", async (request, reply) => {
 });
 
 expectType<Session | null>(app.decodeSecureSession("some cookie"))
-expectType<string>(app.encodeSecureSession(new Session()))
+let session = app.createSecureSession({foo: 'bar'});
+expectType<Session>(session);
+session = app.createSecureSession();
+expectType<Session>(session);
+expectType<string>(app.encodeSecureSession(session))

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -22,3 +22,6 @@ app.get("/not-websockets", async (request, reply) => {
   request.session.get("foo");
   request.session.delete();
 });
+
+expectType<Session | null>(app.decodeSecureSession("some cookie"))
+expectType<string>(app.encodeSecureSession(new Session()))

--- a/test/decorators.js
+++ b/test/decorators.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const fastify = require('fastify')({ logger: false })
+const t = require('tap')
+const Session = require('../').Session
+const sodium = require('sodium-native')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+sodium.randombytes_buf(key)
+
+t.tearDown(fastify.close.bind(fastify))
+
+t.test('it exposes decorators for other libraries to use', async () => {
+  await fastify.register(require('../'), {
+    key
+  })
+  t.ok(fastify.encodeSecureSession(new Session({ foo: 'bar' })))
+  t.ok(fastify.encodeSecureSession(new Session({})))
+  t.notEqual(fastify.encodeSecureSession(new Session({ foo: 'bar' })), fastify.encodeSecureSession(new Session({})))
+
+  const cookie = fastify.encodeSecureSession(new Session({ foo: 'bar' }))
+  const decoded = fastify.decodeSecureSession(cookie)
+  t.equal(decoded.get('foo'), 'bar')
+  t.type(decoded.get('somethingElse'), 'undefined')
+
+  t.equal(fastify.decodeSecureSession('bogus'), null)
+})

--- a/test/decorators.js
+++ b/test/decorators.js
@@ -2,22 +2,26 @@
 
 const fastify = require('fastify')({ logger: false })
 const t = require('tap')
-const Session = require('../').Session
 const sodium = require('sodium-native')
 const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
 sodium.randombytes_buf(key)
 
 t.tearDown(fastify.close.bind(fastify))
 
-t.test('it exposes decorators for other libraries to use', async () => {
+t.test('it exposes encode and decode decorators for other libraries to use', async () => {
   await fastify.register(require('../'), {
     key
   })
-  t.ok(fastify.encodeSecureSession(new Session({ foo: 'bar' })))
-  t.ok(fastify.encodeSecureSession(new Session({})))
-  t.notEqual(fastify.encodeSecureSession(new Session({ foo: 'bar' })), fastify.encodeSecureSession(new Session({})))
 
-  const cookie = fastify.encodeSecureSession(new Session({ foo: 'bar' }))
+  const session = fastify.createSecureSession({ foo: 'bar' })
+  t.equal(session.get('foo'), 'bar')
+  t.type(session.get('somethingElse'), 'undefined')
+
+  t.ok(fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' })))
+  t.ok(fastify.encodeSecureSession(fastify.createSecureSession({})))
+  t.notEqual(fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' })), fastify.encodeSecureSession(fastify.createSecureSession({})))
+
+  const cookie = fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' }))
   const decoded = fastify.decodeSecureSession(cookie)
   t.equal(decoded.get('foo'), 'bar')
   t.type(decoded.get('somethingElse'), 'undefined')


### PR DESCRIPTION
Closes #33

This makes it possible to collaborate with fastify-secure-session from other places where it's hooks don't apply, like custom servers running in the same process or `fastify-websocket` handlers that run outside the normal hook system.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
