### PR TITLE
Expose cookieName

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ const fs = require('fs')
 const path = require('path')
 
 fastify.register(require('fastify-secure-session'), {
+  // the name of the session cookie, defaults to 'session'
+  cookieName: 'my-seession-cookie',
   // adapt this to point to the directory where secret-key is located
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
   cookie: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface Session {
 
 export type SecureSessionPluginOptions = {
   cookie?: CookieSerializeOptions
+  cookieName?: string
 } & ({key: string | Buffer | (string | Buffer)[]} | {
   secret: string | Buffer,
   salt: string | Buffer

--- a/test/cookie-name.js
+++ b/test/cookie-name.js
@@ -8,6 +8,7 @@ const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
 sodium.randombytes_buf(key)
 
 fastify.register(require('../'), {
+  cookieName: 'foobar',
   key
 })
 
@@ -39,7 +40,7 @@ fastify.inject({
   t.equal(response.statusCode, 200)
   t.ok(response.headers['set-cookie'])
   const { name } = response.cookies[0]
-  t.equal(name, 'session')
+  t.equal(name, 'foobar')
 
   fastify.inject({
     method: 'GET',


### PR DESCRIPTION
It is possible to change the cookie name via the `cookieName` option, but it was not documented nor tested.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
