### PR TITLE
Configuring cookie options inside a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const path = require('path')
 
 fastify.register(require('fastify-secure-session'), {
   // the name of the session cookie, defaults to 'session'
-  cookieName: 'my-seession-cookie',
+  cookieName: 'my-session-cookie',
   // adapt this to point to the directory where secret-key is located
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
   cookie: {
@@ -173,6 +173,19 @@ with the key at the first index the next time they are seen by the application, 
 time the older session is decoded will be a little more expensive though.
 
 For a full "start to finish" example without having to generate keys and setup a server file, see the *second* test case in the test file at `/test/key-rotation.js` in this repo.
+
+## Configuring cookie options inside a route
+
+You can configure the options for `setCookie` inside a route by using the `session.options()` method.
+
+```js
+fastify.post('/', (request, reply) => {
+  request.session.set('data', request.body)
+  // .options takes any parameter that you can pass to setCookie
+  request.session.options({ maxAge: 1000 * 60 * 60 })
+  reply.send('hello world')
+})
+```
 
 ## Integrating with other libraries
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface Session {
   get(key: string): any;
   set(key: string, value: any): void;
   delete(): void;
+  options(opts: CookieSerializeOptions): void;
 }
 
 export type SecureSessionPluginOptions = {

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -21,6 +21,7 @@ app.get("/not-websockets", async (request, reply) => {
   request.session.set("foo", "bar");
   request.session.get("foo");
   request.session.delete();
+  request.session.options({ maxAge: 42 })
 });
 
 expectType<Session | null>(app.decodeSecureSession("some cookie"))

--- a/test/dynamic-cookie-options.js
+++ b/test/dynamic-cookie-options.js
@@ -1,55 +1,113 @@
 'use strict'
 
 const t = require('tap')
-const fastify = require('fastify')({ logger: false })
+const Fastify = require('fastify')
 const sodium = require('sodium-native')
+const SecureSessionPlugin = require('../')
 const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
-
 sodium.randombytes_buf(key)
 
-fastify.register(require('../'), {
-  key
-})
+t.test('Custom options', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  fastify.register(SecureSessionPlugin, {
+    key
+  })
 
-fastify.post('/', (request, reply) => {
-  request.session.set('data', request.body)
-  request.session.options({ maxAge: 1000 * 60 * 60 })
-  reply.send('hello world')
-})
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    request.session.options({ maxAge: 1000 * 60 * 60 })
+    reply.send('hello world')
+  })
 
-t.tearDown(fastify.close.bind(fastify))
-t.plan(6)
+  t.tearDown(fastify.close.bind(fastify))
 
-fastify.get('/', (request, reply) => {
-  const data = request.session.get('data')
-  if (!data) {
-    reply.code(404).send()
-    return
-  }
-  reply.send(data)
-})
-
-fastify.inject({
-  method: 'POST',
-  url: '/',
-  payload: {
-    some: 'data'
-  }
-}, (error, response) => {
-  t.error(error)
-  t.equal(response.statusCode, 200)
-  t.ok(response.headers['set-cookie'])
-  const { maxAge } = response.cookies[0]
-  t.equal(maxAge, 1000 * 60 * 60)
+  fastify.get('/', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
 
   fastify.inject({
-    method: 'GET',
+    method: 'POST',
     url: '/',
-    headers: {
-      cookie: response.headers['set-cookie']
+    payload: {
+      some: 'data'
     }
   }, (error, response) => {
     t.error(error)
-    t.deepEqual(JSON.parse(response.payload), { some: 'data' })
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    const { maxAge } = response.cookies[0]
+    t.equal(maxAge, 1000 * 60 * 60)
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.deepEqual(JSON.parse(response.payload), { some: 'data' })
+    })
+  })
+})
+
+t.test('Override global options', t => {
+  t.plan(7)
+  const fastify = Fastify()
+  fastify.register(SecureSessionPlugin, {
+    key,
+    cookieOptions: {
+      maxAge: 42,
+      path: '/'
+    }
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    request.session.options({ maxAge: 1000 * 60 * 60 })
+    reply.send('hello world')
+  })
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    const { maxAge, path } = response.cookies[0]
+    t.equal(maxAge, 1000 * 60 * 60)
+    t.equal(path, '/')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.deepEqual(JSON.parse(response.payload), { some: 'data' })
+    })
   })
 })

--- a/test/dynamic-cookie-options.js
+++ b/test/dynamic-cookie-options.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')({ logger: false })
+const sodium = require('sodium-native')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+
+sodium.randombytes_buf(key)
+
+fastify.register(require('../'), {
+  key
+})
+
+fastify.post('/', (request, reply) => {
+  request.session.set('data', request.body)
+  request.session.options({ maxAge: 1000 * 60 * 60 })
+  reply.send('hello world')
+})
+
+t.tearDown(fastify.close.bind(fastify))
+t.plan(6)
+
+fastify.get('/', (request, reply) => {
+  const data = request.session.get('data')
+  if (!data) {
+    reply.code(404).send()
+    return
+  }
+  reply.send(data)
+})
+
+fastify.inject({
+  method: 'POST',
+  url: '/',
+  payload: {
+    some: 'data'
+  }
+}, (error, response) => {
+  t.error(error)
+  t.equal(response.statusCode, 200)
+  t.ok(response.headers['set-cookie'])
+  const { maxAge } = response.cookies[0]
+  t.equal(maxAge, 1000 * 60 * 60)
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      cookie: response.headers['set-cookie']
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.deepEqual(JSON.parse(response.payload), { some: 'data' })
+  })
+})


### PR DESCRIPTION
Currently, you can't configure the cookie options inside a route, this pr adds a `.options` method to the session object to support this feature.


Closes: https://github.com/fastify/fastify-secure-session/issues/26

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
