### PR TITLE
Demote some log entries to the trace level when they are expected and frequent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ fastify.post('/logout', (request, reply) => {
 })
 ```
 
-If you enable [`debug` logging](https://www.fastify.io/docs/latest/Logging/),
+If you enable [`debug` level logging](https://www.fastify.io/docs/latest/Logging/),
 you will see what steps the library is doing and understand why a session you
-expect to be there is not present.
+expect to be there is not present. For extra details, you can also enable `trace`
+level logging.
 
 ### Using keys as strings
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = fp(function (fastify, options, next) {
   fastify.decorate('decodeSecureSession', (cookie, log = fastify.log) => {
     if (cookie === undefined) {
       // there is no cookie
-      log.debug('fastify-secure-session: there is no cookie, creating an empty session')
+      log.trace('fastify-secure-session: there is no cookie, creating an empty session')
       return null
     }
 
@@ -155,7 +155,7 @@ module.exports = fp(function (fastify, options, next) {
 
       if (!session || !session.changed) {
         // nothing to do
-        request.log.debug('fastify-secure-session: there is no session or the session didn\'t change, leaving it as is')
+        request.log.trace('fastify-secure-session: there is no session or the session didn\'t change, leaving it as is')
         next()
         return
       } else if (session.deleted) {
@@ -171,7 +171,7 @@ module.exports = fp(function (fastify, options, next) {
         return
       }
 
-      request.log.debug('fastify-secure-session: setting session')
+      request.log.trace('fastify-secure-session: setting session')
       reply.setCookie(
         cookieName,
         fastify.encodeSecureSession(session),


### PR DESCRIPTION
This changes some of the log entries `fastify-secure-session` emits to be less verbose at the debug log level. I think this is somewhat a matter of personal taste so I am fine not merging this, but, two entries for every request that is processed completely regularly seems a little overboard, even at `debug`. I think it makes sense to emit something at debug when anything remotely out of the ordinary happens, but `debug` is still supposed to be useful for a developer to go and ... debug ... and I find these entries a little distracting. I think if you want to debug `fastify-secure-session` itself, running at the `trace` level would still get you these entries.

Thoughts?

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
