### PR TITLE
Improve coverage

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,0 @@
-coverage: true

--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,1 @@
-coverage: false
+coverage: true

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = fp(function (fastify, options, next) {
 
     if (!(key instanceof Array) && key.length < sodium.crypto_secretbox_KEYBYTES) {
       return next(new Error(`key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
-    } else if (key instanceof Array && key.some(k => k < sodium.crypto_secretbox_KEYBYTES)) {
+    } else if (key instanceof Array && key.some(k => k.length < sodium.crypto_secretbox_KEYBYTES)) {
       return next(new Error(`key lengths must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
     }
   }

--- a/test/cipher-bad-length.test.js
+++ b/test/cipher-bad-length.test.js
@@ -46,6 +46,9 @@ test('decodeSecureSession should return null if cipher cannot be decrypted', asy
   const firstKey = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
   const secondKey = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
 
+  sodium.randombytes_buf(firstKey)
+  sodium.randombytes_buf(secondKey)
+
   // Creating the initial instance to get a cookie
   // signed by the first key
   let app = createApp(firstKey)

--- a/test/cipher-bad-length.test.js
+++ b/test/cipher-bad-length.test.js
@@ -1,0 +1,40 @@
+const { test } = require('tap')
+const sodium = require('sodium-native')
+
+test('decodeSecureSession should return null when the cipher stored in cookie is not long enough', t => {
+  t.plan(2)
+
+  const app = require('fastify')({ logger: false })
+
+  app
+    .register(
+      require('..'),
+      { key: Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES) }
+    )
+
+  app.get('/', async function (req, rep) {
+    let calledDebug = false
+    const log = { debug () { calledDebug = true } }
+
+    const decodeResult = this.decodeSecureSession(req.cookies.session, log)
+
+    t.equal(calledDebug, true)
+    t.equal(decodeResult, null)
+  })
+
+  app.inject({
+    url: '/',
+    method: 'GET',
+    cookies: {
+      session: createMalformedCookie()
+    }
+  })
+
+  // ***************
+  function createMalformedCookie () {
+    const cyphertextB64 = Buffer.allocUnsafe(sodium.crypto_secretbox_MACBYTES - 1).toString('base64')
+    const nonce = Buffer.allocUnsafe(sodium.crypto_secretbox_NONCEBYTES).toString('base64')
+
+    return `${cyphertextB64};${nonce}`
+  }
+})

--- a/test/cipher-bad-length.test.js
+++ b/test/cipher-bad-length.test.js
@@ -38,3 +38,60 @@ test('decodeSecureSession should return null when the cipher stored in cookie is
     return `${cyphertextB64};${nonce}`
   }
 })
+
+test('decodeSecureSession should return null if cipher cannot be decrypted', async (t) => {
+  t.plan(2)
+
+  // Creating the keys
+  const firstKey = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
+  const secondKey = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
+
+  // Creating the initial instance to get a cookie
+  // signed by the first key
+  let app = createApp(firstKey)
+
+  const encryptedCookie = (await app.inject({ method: 'GET', url: '/' })).cookies[0].value
+
+  // Closing and recreating the app instance
+  await app.close()
+  app = createApp(secondKey)
+
+  // Running the assertions
+  await app.inject({
+    url: '/assert',
+    method: 'GET',
+    cookies: {
+      session: encryptedCookie
+    }
+  })
+
+  // ********************
+  function createApp (key) {
+    const Fastify = require('fastify')
+    const secureSession = require('..')
+    const app = Fastify({ logger: false })
+
+    app.register(secureSession, { key })
+
+    // Setting the session cookie
+    app.get('/', async function (req) {
+      req.session.set('greeting', { hello: 'world' })
+      return 'set!'
+    })
+
+    // Route that runs all of the test's assertions
+    app.get('/assert', async function (req) {
+      let logged = false
+      const decodedSession = this.decodeSecureSession(req.cookies.session, {
+        debug () { logged = true }
+      })
+
+      t.equal(decodedSession, null)
+      t.equal(logged, true)
+
+      return 'verified!'
+    })
+
+    return app
+  }
+})

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.teardown(fastify.close.bind(fastify))
-t.plan(10)
+t.plan(11)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -115,4 +115,27 @@ t.test('plugin should propagate an error when neither a key or a secret was spec
       t.equal(err instanceof Error, true)
       t.equal(err.message, 'key or secret must specified')
     })
+})
+
+t.test('plugin should synchronously throw an error when given a key array with none string keys', t => {
+  t.plan(1)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': (secureSession) => {
+      return secureSession
+    }
+  })
+
+  t.throws(
+    callPlugin,
+    {}
+  )
+
+  // **********************
+  function callPlugin () {
+    secureSession(
+      {},
+      { key: [Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES), 12, Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)] }
+    )
+  }
 })

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.teardown(fastify.close.bind(fastify))
-t.plan(8)
+t.plan(9)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -68,7 +68,7 @@ t.test('plugin should propagate error when given a key that is not an array, str
   })
 })
 
-t.test('plugin should propagate an error when given a key that is shorter than sodium.crypto_secretbox_KEYBYTES', t => {
+t.test('plugin should propagate an error when given a string/buffer key that is shorter than sodium.crypto_secretbox_KEYBYTES', t => {
   t.plan(2)
 
   const secureSession = t.mock('..', {
@@ -81,4 +81,22 @@ t.test('plugin should propagate an error when given a key that is shorter than s
     t.equal(err instanceof Error, true)
     t.equal(err.message, `key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`)
   })
+})
+
+t.test('plugin should propagate an error when given a key array that contains keys shorter than sodium.crypto_secretbox_KEYBYTES', t => {
+  t.plan(2)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': (secureSession) => {
+      return secureSession
+    }
+  })
+
+  secureSession(
+    {},
+    { key: [Buffer.alloc(sodium.crypto_secretbox_KEYBYTES), Buffer.alloc(sodium.crypto_secretbox_KEYBYTES - 1)] },
+    (err) => {
+      t.equal(err instanceof Error, true)
+      t.equal(err.message, `key lengths must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`)
+    })
 })

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.teardown(fastify.close.bind(fastify))
-t.plan(7)
+t.plan(8)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -65,5 +65,20 @@ t.test('plugin should propagate error when given a key that is not an array, str
   secureSession({}, { key: 13 }, (err) => {
     t.equal(err instanceof Error, true)
     t.equal(err.message, 'key must be a string or a Buffer')
+  })
+})
+
+t.test('plugin should propagate an error when given a key that is shorter than sodium.crypto_secretbox_KEYBYTES', t => {
+  t.plan(2)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': (secureSession) => {
+      return secureSession
+    }
+  })
+
+  secureSession({}, { key: Buffer.alloc(sodium.crypto_secretbox_KEYBYTES - 1) }, (err) => {
+    t.equal(err instanceof Error, true)
+    t.equal(err.message, `key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`)
   })
 })

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.teardown(fastify.close.bind(fastify))
-t.plan(9)
+t.plan(10)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -54,7 +54,7 @@ fastify.inject({
 })
 
 t.test('plugin should propagate error when given a key that is not an array, string, or buffer', t => {
-  t.plan(2)
+  t.plan(1)
 
   const secureSession = t.mock('..', {
     'fastify-plugin': (secureSession) => {
@@ -64,12 +64,11 @@ t.test('plugin should propagate error when given a key that is not an array, str
 
   secureSession({}, { key: 13 }, (err) => {
     t.equal(err instanceof Error, true)
-    t.equal(err.message, 'key must be a string or a Buffer')
   })
 })
 
 t.test('plugin should propagate an error when given a string/buffer key that is shorter than sodium.crypto_secretbox_KEYBYTES', t => {
-  t.plan(2)
+  t.plan(1)
 
   const secureSession = t.mock('..', {
     'fastify-plugin': (secureSession) => {
@@ -79,7 +78,6 @@ t.test('plugin should propagate an error when given a string/buffer key that is 
 
   secureSession({}, { key: Buffer.alloc(sodium.crypto_secretbox_KEYBYTES - 1) }, (err) => {
     t.equal(err instanceof Error, true)
-    t.equal(err.message, `key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`)
   })
 })
 
@@ -98,5 +96,23 @@ t.test('plugin should propagate an error when given a key array that contains ke
     (err) => {
       t.equal(err instanceof Error, true)
       t.equal(err.message, `key lengths must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`)
+    })
+})
+
+t.test('plugin should propagate an error when neither a key or a secret was specified', t => {
+  t.plan(2)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': (secureSession) => {
+      return secureSession
+    }
+  })
+
+  secureSession(
+    {},
+    {},
+    (err) => {
+      t.equal(err instanceof Error, true)
+      t.equal(err.message, 'key or secret must specified')
     })
 })

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.teardown(fastify.close.bind(fastify))
-t.plan(6)
+t.plan(7)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -50,5 +50,20 @@ fastify.inject({
   }, (error, response) => {
     t.error(error)
     t.same(JSON.parse(response.payload), { some: 'data' })
+  })
+})
+
+t.test('plugin should propagate error when given a key that is not an array, string, or buffer', t => {
+  t.plan(2)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': (secureSession) => {
+      return secureSession
+    }
+  })
+
+  secureSession({}, { key: 13 }, (err) => {
+    t.equal(err instanceof Error, true)
+    t.equal(err.message, 'key must be a string or a Buffer')
   })
 })

--- a/test/secret.js
+++ b/test/secret.js
@@ -175,3 +175,21 @@ tap.test('plugin should propagate error when fed a secret that is shorter than 3
     t.equal(err instanceof Error, true)
   })
 })
+tap.test('plugin should propagate error when fed a salt that is shorter than sodium.crypto_pwhash_SALTBYTES', function (t) {
+  t.plan(2)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': function (secureSession) {
+      return secureSession
+    }
+  })
+  const sodium = require('sodium-native')
+
+  const secret = 'averylogphrasebiggerthanthirtytwochars'
+  const shortSalt = Buffer.from('mq9hDxBVDbsp', 'ascii')
+
+  secureSession({}, { secret: secret, salt: shortSalt }, function next (err) {
+    t.equal(err instanceof Error, true)
+    t.equal(err.message, `salt must be length ${sodium.crypto_pwhash_SALTBYTES}`)
+  })
+})

--- a/test/secret.js
+++ b/test/secret.js
@@ -175,21 +175,20 @@ tap.test('plugin should propagate error when fed a secret that is shorter than 3
     t.equal(err instanceof Error, true)
   })
 })
+
 tap.test('plugin should propagate error when fed a salt that is shorter than sodium.crypto_pwhash_SALTBYTES', function (t) {
-  t.plan(2)
+  t.plan(1)
 
   const secureSession = t.mock('..', {
     'fastify-plugin': function (secureSession) {
       return secureSession
     }
   })
-  const sodium = require('sodium-native')
 
   const secret = 'averylogphrasebiggerthanthirtytwochars'
   const shortSalt = Buffer.from('mq9hDxBVDbsp', 'ascii')
 
   secureSession({}, { secret: secret, salt: shortSalt }, function next (err) {
     t.equal(err instanceof Error, true)
-    t.equal(err.message, `salt must be length ${sodium.crypto_pwhash_SALTBYTES}`)
   })
 })

--- a/test/secret.js
+++ b/test/secret.js
@@ -159,3 +159,19 @@ tap.test('using secret with salt as buffer', function (t) {
     })
   })
 })
+
+tap.test('plugin should propagate error when fed a secret that is shorter than 32 bytes', function (t) {
+  t.plan(1)
+
+  const secureSession = t.mock('..', {
+    'fastify-plugin': function (secureSession) {
+      return secureSession
+    }
+  })
+
+  const shortSecret = Buffer.alloc(16)
+
+  secureSession({}, { secret: shortSecret }, function next (err) {
+    t.equal(err instanceof Error, true)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #67 

This PR adds additional tests that boost the overall test coverage to 100%, it also fixes an [unrecorded bug](https://github.com/fastify/fastify-secure-session/blob/master/index.js#L49) at line 49 which caused buffer keys that are passed inside an array to the `key` option prop not be validated because of implicit coercion the `<` operator will always return `false`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
