### PR TITLE
feat: use npx for keygen and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ and [fastify-cookie](https://github.com/fastify/fastify-cookie).
 
 First generate a key with:
 
+```sh
+npx fastify-secure-session > secret-key
 ```
-./node_modules/.bin/secure-session-gen-key > secret-key
+
+If running in Windows Powershell, you should use this command instead:
+
+```sh
+npx fastify-secure-session | Out-File -Encoding default -NoNewline -FilePath secret-key
 ```
 
 Then, register the plugin as follows:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
-    "secure-session-gen-key": "genkey.js"
+    "fastify-secure-session": "genkey.js"
   },
   "scripts": {
     "test": "standard && tap test/*.js && tsd"


### PR DESCRIPTION
Closes #87 

- name bin script so it can be used via npx (it should match the package name)
- update docs to:
  - show npx instead of running keygen via node
  - show how to use with powershell

I confirmed that the powershell command suggested in the issue works by printing the byte length of the generated key, which is 32 with the right command syntax and 70 with the wrong one:

### wrong 

```
npx -p . fastify-secure-session > secret-key
node -e "console.log(require('fs').readFileSync('./secret-key').length)"
70
```

### right

```
npx -p . fastify-secure-session | Out-File -Encoding default -NoNewline -FilePath secret-key
node -e "console.log(require('fs').readFileSync('./secret-key').length)"
32
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
