### PR TITLE
Support for state in oauth scenarios

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,9 +121,11 @@ module.exports = fp(function (fastify, options, next) {
     if (session[kObj].state) {
       const stateKey = session[kObj].state.key
       session[stateKey] = { state: session[kObj].state.value }
+      session.changed = true
+    } else {
+      session.changed = signingKeyRotated
     }
 
-    session.changed = signingKeyRotated
     return session
   })
 


### PR DESCRIPTION
This PR tries to fix the issue reported in `fastify-passport` (https://github.com/fastify/fastify-passport/issues/376)

Issue: When `state` is used in an oauth strategy along with `fastify-secure-session` then the `state` is not being encoded because we only encode `session[kObj]`. As a result when the callback happens the local state does not exist.

Fix: I have tried to add the `state` to `session[kObj]` before the encoding happens and restore it after decoding so that state verification is done correctly.

I am not sure if this fix is the right way to do it. Any suggestions to improve the PR are welcome!