### PR TITLE
Rename module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { CookieSerializeOptions } from "fastify-cookie";
+import { CookieSerializeOptions } from "@fastify/cookie";
 import { FastifyPlugin, FastifyLoggerInstance } from "fastify";
 
 export interface Session {

--- a/index.js
+++ b/index.js
@@ -160,13 +160,13 @@ module.exports = fp(function (fastify, options, next) {
   })
 
   fastify
-    .register(require('fastify-cookie'))
+    .register(require('@fastify/cookie'))
     .register(fp(addHooks))
 
   next()
 
   function addHooks (fastify, options, next) {
-    // the hooks must be registered after fastify-cookie hooks
+    // the hooks must be registered after @fastify/cookie hooks
 
     fastify.addHook('onRequest', (request, reply, next) => {
       const cookie = request.cookies[cookieName]

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "fastify-cookie": "^5.0.0",
+    "@fastify/cookie": "^6.0.0",
     "fastify-plugin": "^3.0.0",
     "sodium-native": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-secure-session",
-  "version": "3.1.0",
+  "name": "@fastify/secure-session",
+  "version": "4.0.0",
   "description": "Create a secure stateless cookie session for Fastify",
   "main": "index.js",
   "types": "index.d.ts",
@@ -40,5 +40,8 @@
     "fastify-cookie": "^5.0.0",
     "fastify-plugin": "^3.0.0",
     "sodium-native": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important:** no further releases should be added to the old major version.
