### PR TITLE
fix: add support for empty key array at plugin registration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ fastify.listen(3000)
 
 ## Using Keys with key rotation
 
-It is possible to use an array for the key field to support key rotation as an additional security measure.
+It is possible to use an non-empty array for the key field to support key rotation as an additional security measure.
 Cookies will always be signed with the first key in the array to try to "err on the side of performance" however
 if decoding the key fails, it will attempt to decode using every subsequent value in the key array.
 
@@ -177,7 +177,7 @@ fastify.register(require('@fastify/secure-session'), {
 })
 ```
 
-See that `myNewKey` was added to the first index postion in the key array. This allows any sessions that were created
+See that `myNewKey` was added to the first index position in the key array. This allows any sessions that were created
 with the original `mySecureKey` to still be decoded. The first time a session signed with an older key is "seen", by the application, this library will re-sign the cookie with the newest session key therefore improving performance for any subsequent session decodes.
 
 To see a full working example, make sure you generate `secret-key1` and `secret-key2` alongside the js file below by running:

--- a/index.js
+++ b/index.js
@@ -70,9 +70,9 @@ module.exports = fp(function (fastify, options, next) {
       return next(new Error('key must be a string or a Buffer'))
     }
 
-    if (!(key instanceof Array) && key.length < sodium.crypto_secretbox_KEYBYTES) {
+    if (!(key instanceof Array) && isBufferKeyLengthValid(key)) {
       return next(new Error(`key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
-    } else if (key instanceof Array && key.some(k => k < sodium.crypto_secretbox_KEYBYTES)) {
+    } else if (key instanceof Array && key.every(isBufferKeyLengthValid)) {
       return next(new Error(`key lengths must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
     }
   }
@@ -263,4 +263,8 @@ function ensureBufferKey (k) {
   }
 
   return Buffer.from(k, 'base64')
+}
+
+function isBufferKeyLengthValid (k) {
+  return k.length < sodium.crypto_secretbox_KEYBYTES
 }

--- a/test/key-rotation.js
+++ b/test/key-rotation.js
@@ -148,3 +148,16 @@ tap.test('support key rotation with buffer key array', async t => {
   t.equal(getResponseNewKey.statusCode, 200)
   t.same(JSON.parse(getResponseNewKey.payload), payload)
 })
+
+tap.test('does not support an empty key array', async t => {
+  const fastify = Fastify({ logger: false })
+
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(1)
+
+  fastify.register(fastifySecureSession, {
+    key: []
+  })
+
+  await t.rejects(() => fastify.after())
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hello fastifiers,

**Issue**

Here is the PR following the opening of the issue discussed here #127.

**Context**

Previously when providing an empty key array, no error was thrown (not in the same way as when providing an invalid string/buffer for example).

**Solution**

Consequently, the goal of this PR is to throw an error at plugin registration time rather than at runtime when this case is met.

```js
// should throw an error
fastify.register(fastifySecureSession, {
    key: []
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
