### PR TITLE
Adds types for setters and gettors in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 import { CookieSerializeOptions } from "@fastify/cookie";
 import { FastifyPlugin, FastifyLoggerInstance } from "fastify";
 
-export interface Session {
+export type Session = Partial<SessionData> & {
   changed: boolean;
   deleted: boolean;
   get<Key extends keyof SessionData>(key: Key): SessionData[Key] | undefined;

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -27,6 +27,8 @@ app.get("/not-websockets", async (request, reply) => {
   request.session.set("foo", "bar");
   expectType<string | undefined>(request.session.get("foo"));
   expectType<any>(request.session.get("baz"));
+  expectType<string | undefined>(request.session.foo));
+  expectType<any>(request.session.baz);
   expectType<SessionData | undefined>(request.session.data());
   request.session.delete();
   request.session.options({ maxAge: 42 })

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -27,7 +27,7 @@ app.get("/not-websockets", async (request, reply) => {
   request.session.set("foo", "bar");
   expectType<string | undefined>(request.session.get("foo"));
   expectType<any>(request.session.get("baz"));
-  expectType<string | undefined>(request.session.foo));
+  expectType<string | undefined>(request.session.foo);
   expectType<any>(request.session.baz);
   expectType<SessionData | undefined>(request.session.data());
   request.session.delete();


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Allows to use the gettors and settors with typescript. The changes to the .d.ts file have been tested locally and they seem to work properly. ~~The test has not.~~ Test has also been tested locally now

This will prevent declaration merging with the Session object itself (SessionData remains unchanged and can still be merged) but there doesnt seem to be a way to decorate it so it should be fine.

I don't believe documentation is required as this is pretty much expected behavior.