### PR TITLE
fix: ensure that the length of the secret keys are sodium-native compliant at plugin registration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ fastify.register(require('@fastify/secure-session'), {
 })
 ```
 
+Note: `key` must be a secret key of length [crypto_secretbox_KEYBYTES](https://sodium-friends.github.io/docs/docs/secretkeyboxencryption).
+
 #### Security
 
 - Although the example reads the key from a file on disk, it is poor practice when it comes to security. Ideally, you should store secret/keys into a key management service like Vault, KMS or something similar and read them at run-time.

--- a/index.js
+++ b/index.js
@@ -70,10 +70,10 @@ module.exports = fp(function (fastify, options, next) {
       return next(new Error('key must be a string or a Buffer'))
     }
 
-    if (!(key instanceof Array) && isBufferKeyLengthValid(key)) {
-      return next(new Error(`key must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
-    } else if (key instanceof Array && key.every(isBufferKeyLengthValid)) {
-      return next(new Error(`key lengths must be at least ${sodium.crypto_secretbox_KEYBYTES} bytes`))
+    if (!(key instanceof Array) && isBufferKeyLengthInvalid(key)) {
+      return next(new Error(`key must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
+    } else if (key instanceof Array && key.every(isBufferKeyLengthInvalid)) {
+      return next(new Error(`key lengths must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
     }
   }
 
@@ -265,6 +265,8 @@ function ensureBufferKey (k) {
   return Buffer.from(k, 'base64')
 }
 
-function isBufferKeyLengthValid (k) {
-  return k.length < sodium.crypto_secretbox_KEYBYTES
+function isBufferKeyLengthInvalid (k) {
+  // the key should be strictly equals to sodium.crypto_secretbox_KEYBYTES
+  // or this will result in a runtime error when encoding the session
+  return k.length !== sodium.crypto_secretbox_KEYBYTES
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Hello,

This PR is related to the following issue #131.

So far at registration time each `key` could be equal or greater than 32 bytes. 
The goal of this PR is to ensure that each `key` provided in the plugin configuration satisfies the length constraint of `sodium-native` (strictly equal to 32 bytes) at plugin registration time ([see more here](https://sodium-friends.github.io/docs/docs/secretkeyboxencryption)).

I don't know if we should consider this as a breaking change, because if one was already using keys greater than 32 bytes, the runtime error specified in the issue would have been thrown anyway while encoding the session.
