### PR TITLE
chore: enable coverage threshold

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,1 @@
-coverage: false
+coverage: true

--- a/index.js
+++ b/index.js
@@ -65,7 +65,11 @@ module.exports = fp(function (fastify, options, next) {
     if (typeof key === 'string') {
       key = Buffer.from(key, 'base64')
     } else if (key instanceof Array) {
-      key = key.map(ensureBufferKey)
+      try {
+        key = key.map(ensureBufferKey)
+      } catch (error) {
+        return next(error)
+      }
     } else if (!(key instanceof Buffer)) {
       return next(new Error('key must be a string or a Buffer'))
     }

--- a/test/key.js
+++ b/test/key.js
@@ -5,6 +5,20 @@ const Fastify = require('fastify')
 const fastifySecureSession = require('..')
 const sodium = require('sodium-native')
 
+tap.test('throws when key is not string array nor a Buffer array', async t => {
+  t.plan(2)
+
+  const fastify = Fastify({ logger: false })
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(fastifySecureSession, {
+    key: [true]
+  }).after(err => {
+    t.type(err, Error)
+    t.equal(err.message, 'Key must be string or buffer')
+  })
+})
+
 tap.test('throws when key is not string nor a Buffer', async t => {
   t.plan(2)
 


### PR DESCRIPTION
Closes #67

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

before:
```
$ npm test

> @fastify/secure-session@5.1.0 test
> standard && tap test/*.js && tsd

 PASS  test/decorators.js 9 OK 476.337ms
 PASS  test/cookie-name.js 6 OK 176.673ms
 PASS  test/delete.js 14 OK 185.863ms
 PASS  test/key-base64.js 5 OK 180.375ms
 PASS  test/dynamic-cookie-options.js 13 OK 215.872ms
 PASS  test/access.js 20 OK 223.37ms
 PASS  test/key.js 12 OK 218.558ms
 PASS  test/key-rotation.js 11 OK 228.118ms
 PASS  test/malformed-cookie.js 5 OK 181.394ms
 PASS  test/nonce-bad-length.test.js 5 OK 116.13ms
 PASS  test/path.js 4 OK 129.719ms
 PASS  test/salt.js 5 OK 113.297ms
 PASS  test/schema.js 6 OK 137.425ms
 PASS  test/secret.js 21 OK 2s



  🌈 SUMMARY RESULTS 🌈


Suites:   14 passed, 14 of 14 completed
Asserts:  136 passed, of 136
Time:   5s
ERROR: Coverage for lines (97.58%) does not meet global threshold (100%)
ERROR: Coverage for branches (96.87%) does not meet global threshold (100%)
ERROR: Coverage for statements (97.6%) does not meet global threshold (100%)
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |    97.6 |    96.87 |     100 |   97.58 |
 index.js |    97.6 |    96.87 |     100 |   97.58 | 141-142,262
----------|---------|----------|---------|---------|-------------------
```

after:
```
$ npm test

> @fastify/secure-session@5.1.0 test
> standard && tap test/*.js && tsd

 PASS  test/decorators.js 10 OK 395.743ms
 PASS  test/key-base64.js 5 OK 162.104ms
 PASS  test/cookie-name.js 6 OK 147.966ms
 PASS  test/delete.js 14 OK 169.664ms
 PASS  test/key-rotation.js 11 OK 185.2ms
 PASS  test/access.js 20 OK 198.482ms
 PASS  test/key.js 14 OK 223.696ms
 PASS  test/dynamic-cookie-options.js 13 OK 201.506ms
 PASS  test/malformed-cookie.js 5 OK 128.976ms
 PASS  test/nonce-bad-length.test.js 5 OK 124.4ms
 PASS  test/salt.js 5 OK 130.635ms
 PASS  test/path.js 4 OK 129.033ms
 PASS  test/schema.js 6 OK 144.612ms
 PASS  test/secret.js 21 OK 2s



  🌈 SUMMARY RESULTS 🌈


Suites:   14 passed, 14 of 14 completed
Asserts:  139 passed, of 139
Time:   4s
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |
 index.js |     100 |      100 |     100 |     100 |
----------|---------|----------|---------|---------|-------------------
```