### PR TITLE
fix: no new cookie if session data is unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ you will see what steps the library is doing and understand why a session you
 expect to be there is not present. For extra details, you can also enable `trace`
 level logging.
 
-Note: instead of using the `get` and `set` methods as seen above, you may also wish to use property getters and setters to make your code compatible with other libraries ie `request.session.data = request.body` and `const data = request.session.data` are also possible.
+Note: Instead of using the `get` and `set` methods as seen above, you may also wish to use property getters and setters to make your code compatible with other libraries ie `request.session.data = request.body` and `const data = request.session.data` are also possible. However, if you want to have properties named `changed` or `deleted` in your session data, they can only be accessed via `session.get()` and `session.set()`. (Those are the names of internal properties used by the Session object)
 
 ### Using keys as strings
 

--- a/index.js
+++ b/index.js
@@ -253,8 +253,7 @@ class Session {
   }
 
   data () {
-    const { changed, deleted, ...data } = this[kObj]
-    return data
+    return this[kObj]
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const sessionProxyHandler = {
       })
     }
 
-    // Accessing properties eg request.session.changed
+    // accessing own properties, eg request.session.changed
     if (Object.prototype.hasOwnProperty.call(target, prop)) {
       return target[prop]
     }
@@ -26,6 +26,13 @@ const sessionProxyHandler = {
     return target.get(prop)
   },
   set (target, prop, value) {
+    // modifying own properties, eg request.session.changed
+    if (Object.prototype.hasOwnProperty.call(target, prop)) {
+      target[prop] = value
+      return true
+    }
+
+    // modifying session property
     target.set(prop, value)
     return true
   }


### PR DESCRIPTION
Fixes #144 

This addresses the issue where a new cookie was being made on every request, regardless of whether the session data was actually changed. It also prevents the buggy behavior where the `changed` property was ending up in the actual Session data. To fix this, I basically just copied the `hasOwnProperty` check from the get() to the set() method in the Session's proxy handler.

I modified the 'session is changed' test to verify the above is working. I also added a little note in the docs to clarify the edge case where someone might want properties named `changed` or `deleted` in their Session data. Hopefully this will already be clear due to the typing of the Session object, so I'd be fine with removing that note if not needed.

In the future, we might want to look into revamping the shape of the Session object to prevent confusion (perhaps rename `changed` and `deleted` to reflect that they are internal properties used to track changes) - but that's probably outside the scope of this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
