### PR TITLE
use npx instead of node_modules in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ with the original `mySecureKey` to still be decoded. The first time a session si
 To see a full working example, make sure you generate `secret-key1` and `secret-key2` alongside the js file below by running:
 
 ```
-./node_modules/.bin/secure-session-gen-key > secret-key1
-./node_modules/.bin/secure-session-gen-key > secret-key2
+npx @fastify/secure-session > secret-key1
+npx @fastify/secure-session > secret-key2
 ```
 
 ```js


### PR DESCRIPTION
Maybe makes more sense to direct reference to npx instead of node_modules in the readme.md

Also I guess the code in the readme.md would not work anyway...

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
