### PR TITLE
fix: 134 document genkey without npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ To avoid this use the `--yes` flag with npx:
 npx --yes @fastify/secure-session > secret-key
 ```
 
+If you don't want to use `npx`, you can still generate the `secret-key` installing the `@fastify/secure-session` library with your choice package manager, and then:
+
+```sh
+./node_modules/@fastify/secure-session/genkey.js > secret_key
+```
+
 Then, register the plugin as follows:
 
 ```js


### PR DESCRIPTION
It closes #134 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included - not needed for this change
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### Main changes:

- documented how to generate a `secret-key` without using `npx`, this means that you can use your preferred package manager.