### PR TITLE
add support for custom session key and multiple sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fastify.post('/', (request, reply) => {
   request.session.set('data', request.body)
 
   // or when using a custom sessionName: 
-  request.customsessionName.set('data', request.body)
+  request.customSessionName.set('data', request.body)
 
   reply.send('hello world')
 })

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ const fs = require('fs')
 const path = require('path')
 
 fastify.register(require('@fastify/secure-session'), {
-  // the name of the session cookie, defaults to 'session'
+  // the name of the attribute decorated on the request-object, defaults to 'session'
+  fieldName: 'my-session',
+  // the name of the session cookie, defaults to value of fieldName
   cookieName: 'my-session-cookie',
   // adapt this to point to the directory where secret-key is located
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
@@ -290,6 +292,25 @@ declare module '@fastify/secure-session' {
 
 fastify.get('/', (request, reply) => {
   request.session.get('foo'); // typed `string | undefined`
+  reply.send('hello world')
+})
+```
+
+When using a custom fieldName the types should be configured as follows:
+
+```ts
+interface FooSessionData {
+  foo: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    foo: Session<FooSessionData>;
+  }
+}
+
+fastify.get('/', (request, reply) => {
+  request.foo.get('foo'); // typed `string | undefined`
   reply.send('hello world')
 })
 ```

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ const path = require('path')
 
 fastify.register(require('@fastify/secure-session'), {
   // the name of the attribute decorated on the request-object, defaults to 'session'
-  fieldName: 'my-session',
-  // the name of the session cookie, defaults to value of fieldName
+  sessionKey: 'my-session',
+  // the name of the session cookie, defaults to value of sessionKey
   cookieName: 'my-session-cookie',
   // adapt this to point to the directory where secret-key is located
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
@@ -296,7 +296,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-When using a custom fieldName the types should be configured as follows:
+When using a custom sessionKey the types should be configured as follows:
 
 ```ts
 interface FooSessionData {

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ const path = require('path')
 
 fastify.register(require('@fastify/secure-session'), {
   // the name of the attribute decorated on the request-object, defaults to 'session'
-  sessionKey: 'session',
-  // the name of the session cookie, defaults to value of sessionKey
+  sessionName: 'session',
+  // the name of the session cookie, defaults to value of sessionName
   cookieName: 'my-session-cookie',
   // adapt this to point to the directory where secret-key is located
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
@@ -62,8 +62,8 @@ fastify.register(require('@fastify/secure-session'), {
 fastify.post('/', (request, reply) => {
   request.session.set('data', request.body)
 
-  // or when using a custom sessionKey: 
-  request.customSessionKey.set('data', request.body)
+  // or when using a custom sessionName: 
+  request.customsessionName.set('data', request.body)
 
   reply.send('hello world')
 })
@@ -93,18 +93,18 @@ Note: Instead of using the `get` and `set` methods as seen above, you may also w
 
 ### Multiple sessions
 
-If you want to use multiple sessions, you have to supply an array of options when registering the plugin. It supports the same options as a single session but in this case, the `sessionKey` name is mandatory.
+If you want to use multiple sessions, you have to supply an array of options when registering the plugin. It supports the same options as a single session but in this case, the `sessionName` name is mandatory.
 
 ```js
 fastify.register(require('@fastify/secure-session'), [{
-  sessionKey: 'mySession',
+  sessionName: 'mySession',
   cookieName: 'my-session-cookie',
   key: fs.readFileSync(path.join(__dirname, 'secret-key')),
   cookie: {
     path: '/'
   }
 }, {
-  sessionKey: 'myOtherSession',
+  sessionName: 'myOtherSession',
   key: fs.readFileSync(path.join(__dirname, 'another-secret-key')),
   cookie: {
     path: '/path',
@@ -312,7 +312,7 @@ fastify.decodeSecureSession(request.cookies['session'])
 // => Session | null  returns a session object which you can use to .get values from if decoding is successful, and null otherwise
 ```
 
-When using multiple sessions, you will have to provide the sessionKey when encoding and decoding the session.
+When using multiple sessions, you will have to provide the sessionName when encoding and decoding the session.
 
 ```js
 fastify.encodeSecureSession(request.session, 'mySecondSession')
@@ -337,7 +337,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-When using a custom sessionKey or using multiple sessions the types should be configured as follows:
+When using a custom sessionName or using multiple sessions the types should be configured as follows:
 
 ```ts
 interface FooSessionData {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const path = require('path')
 
 fastify.register(require('@fastify/secure-session'), {
   // the name of the attribute decorated on the request-object, defaults to 'session'
-  sessionKey: 'my-session',
+  sessionKey: 'session',
   // the name of the session cookie, defaults to value of sessionKey
   cookieName: 'my-session-cookie',
   // adapt this to point to the directory where secret-key is located
@@ -61,6 +61,10 @@ fastify.register(require('@fastify/secure-session'), {
 
 fastify.post('/', (request, reply) => {
   request.session.set('data', request.body)
+
+  // or when using a custom sessionKey: 
+  request.customSessionKey.set('data', request.body)
+
   reply.send('hello world')
 })
 
@@ -85,6 +89,35 @@ expect to be there is not present. For extra details, you can also enable `trace
 level logging.
 
 Note: Instead of using the `get` and `set` methods as seen above, you may also wish to use property getters and setters to make your code compatible with other libraries ie `request.session.data = request.body` and `const data = request.session.data` are also possible. However, if you want to have properties named `changed` or `deleted` in your session data, they can only be accessed via `session.get()` and `session.set()`. (Those are the names of internal properties used by the Session object)
+
+
+### Multiple sessions
+
+If you want to use multiple sessions, you have to supply an array of options when registering the plugin. It supports the same options as a single session but in this case, the `sessionKey` name is mandatory.
+
+```js
+fastify.register(require('@fastify/secure-session'), [{
+  sessionKey: 'mySession',
+  cookieName: 'my-session-cookie',
+  key: fs.readFileSync(path.join(__dirname, 'secret-key')),
+  cookie: {
+    path: '/'
+  }
+}, {
+  sessionKey: 'myOtherSession',
+  key: fs.readFileSync(path.join(__dirname, 'another-secret-key')),
+  cookie: {
+    path: '/path',
+    maxAge: 100
+  }
+}])
+
+fastify.post('/', (request, reply) => {
+  request.mySession.set('data', request.body)
+  request.myOtherSession.set('data', request.body)
+  reply.send('hello world')
+})
+```
 
 ### Using keys as strings
 
@@ -279,6 +312,14 @@ fastify.decodeSecureSession(request.cookies['session'])
 // => Session | null  returns a session object which you can use to .get values from if decoding is successful, and null otherwise
 ```
 
+When using multiple sessions, you will have to provide the sessionKey when encoding and decoding the session.
+
+```js
+fastify.encodeSecureSession(request.session, 'mySecondSession')
+
+fastify.decodeSecureSession(request.cookies['session'], undefined, 'mySecondSession')
+```
+
 ## Add TypeScript types
 
 The session data is typed as `{ [key: string]: any }`. This can be extended with [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to get improved type support.
@@ -296,7 +337,7 @@ fastify.get('/', (request, reply) => {
 })
 ```
 
-When using a custom sessionKey the types should be configured as follows:
+When using a custom sessionKey or using multiple sessions the types should be configured as follows:
 
 ```ts
 interface FooSessionData {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function fastifySecureSession (fastify, options, next) {
     options = [options]
   }
 
-  let defaultsessionName
+  let defaultSessionName
   const sessionNames = new Map()
 
   for (const sessionOptions of options) {
@@ -118,12 +118,12 @@ function fastifySecureSession (fastify, options, next) {
       key
     })
 
-    if (!defaultsessionName) {
-      defaultsessionName = sessionName
+    if (!defaultSessionName) {
+      defaultSessionName = sessionName
     }
   }
 
-  fastify.decorate('decodeSecureSession', (cookie, log = fastify.log, sessionName = defaultsessionName) => {
+  fastify.decorate('decodeSecureSession', (cookie, log = fastify.log, sessionName = defaultSessionName) => {
     if (cookie === undefined) {
       // there is no cookie
       log.trace('@fastify/secure-session: there is no cookie, creating an empty session')
@@ -186,7 +186,7 @@ function fastifySecureSession (fastify, options, next) {
 
   fastify.decorate('createSecureSession', (data) => new Proxy(new Session(data), sessionProxyHandler))
 
-  fastify.decorate('encodeSecureSession', (session, sessionName = defaultsessionName) => {
+  fastify.decorate('encodeSecureSession', (session, sessionName = defaultSessionName) => {
     if (!sessionNames.has(sessionName)) {
       throw new Error('Unknown session key.')
     }

--- a/index.js
+++ b/index.js
@@ -39,143 +39,168 @@ const sessionProxyHandler = {
 }
 
 function fastifySecureSession (fastify, options, next) {
-  let key
-  if (options.secret) {
-    if (Buffer.byteLength(options.secret) < 32) {
-      return next(new Error('secret must be at least 32 bytes'))
-    }
-
-    key = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
-
-    // static salt to be used for key derivation, not great for security,
-    // but better than nothing
-    let salt = Buffer.from('mq9hDxBVDbspDR6nLfFT1g==', 'base64')
-
-    if (options.salt) {
-      salt = (Buffer.isBuffer(options.salt)) ? options.salt : Buffer.from(options.salt, 'ascii')
-    }
-
-    if (Buffer.byteLength(salt) !== sodium.crypto_pwhash_SALTBYTES) {
-      return next(new Error('salt must be length ' + sodium.crypto_pwhash_SALTBYTES))
-    }
-
-    sodium.crypto_pwhash(key,
-      Buffer.from(options.secret),
-      salt,
-      sodium.crypto_pwhash_OPSLIMIT_MODERATE,
-      sodium.crypto_pwhash_MEMLIMIT_MODERATE,
-      sodium.crypto_pwhash_ALG_DEFAULT)
+  if (!(options instanceof Array)) {
+    options = [options]
   }
 
-  if (options.key) {
-    key = options.key
-    if (typeof key === 'string') {
-      key = Buffer.from(key, 'base64')
-    } else if (key instanceof Array) {
-      try {
-        key = key.map(ensureBufferKey)
-      } catch (error) {
-        return next(error)
+  let defaultSessionKey
+  const sessionKeys = new Map()
+
+  for (const sessionOptions of options) {
+    const sessionKey = sessionOptions.sessionKey || 'session'
+    const cookieName = sessionOptions.cookieName || sessionKey
+    const cookieOptions = sessionOptions.cookieOptions || sessionOptions.cookie || {}
+
+    let key
+    if (sessionOptions.secret) {
+      if (Buffer.byteLength(sessionOptions.secret) < 32) {
+        return next(new Error('secret must be at least 32 bytes'))
       }
-    } else if (!(key instanceof Buffer)) {
-      return next(new Error('key must be a string or a Buffer'))
+
+      key = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
+
+      // static salt to be used for key derivation, not great for security,
+      // but better than nothing
+      let salt = Buffer.from('mq9hDxBVDbspDR6nLfFT1g==', 'base64')
+
+      if (sessionOptions.salt) {
+        salt = (Buffer.isBuffer(sessionOptions.salt)) ? sessionOptions.salt : Buffer.from(sessionOptions.salt, 'ascii')
+      }
+
+      if (Buffer.byteLength(salt) !== sodium.crypto_pwhash_SALTBYTES) {
+        return next(new Error('salt must be length ' + sodium.crypto_pwhash_SALTBYTES))
+      }
+
+      sodium.crypto_pwhash(key,
+        Buffer.from(sessionOptions.secret),
+        salt,
+        sodium.crypto_pwhash_OPSLIMIT_MODERATE,
+        sodium.crypto_pwhash_MEMLIMIT_MODERATE,
+        sodium.crypto_pwhash_ALG_DEFAULT)
     }
 
-    if (!(key instanceof Array) && isBufferKeyLengthInvalid(key)) {
-      return next(new Error(`key must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
-    } else if (key instanceof Array && key.every(isBufferKeyLengthInvalid)) {
-      return next(new Error(`key lengths must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
+    if (sessionOptions.key) {
+      key = sessionOptions.key
+      if (typeof key === 'string') {
+        key = Buffer.from(key, 'base64')
+      } else if (key instanceof Array) {
+        try {
+          key = key.map(ensureBufferKey)
+        } catch (error) {
+          return next(error)
+        }
+      } else if (!(key instanceof Buffer)) {
+        return next(new Error('key must be a string or a Buffer'))
+      }
+
+      if (!(key instanceof Array) && isBufferKeyLengthInvalid(key)) {
+        return next(new Error(`key must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
+      } else if (key instanceof Array && key.every(isBufferKeyLengthInvalid)) {
+        return next(new Error(`key lengths must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
+      }
+    }
+
+    if (!key) {
+      return next(new Error('key or secret must specified'))
+    }
+
+    if (!(key instanceof Array)) {
+      key = [key]
+    }
+
+    // just to add something to the shape
+    // TODO verify if it helps the perf
+    fastify.decorateRequest(sessionKey, null)
+
+    sessionKeys.set(sessionKey, {
+      cookieName,
+      cookieOptions,
+      key
+    })
+
+    if (!defaultSessionKey) {
+      defaultSessionKey = sessionKey
     }
   }
 
-  if (!key) {
-    return next(new Error('key or secret must specified'))
-  }
-
-  if (!(key instanceof Array)) {
-    key = [key]
-  }
-
-  const sessionKey = options.sessionKey || 'session'
-  const cookieName = options.cookieName || sessionKey
-  const cookieOptions = options.cookieOptions || options.cookie || {}
-
-  // just to add something to the shape
-  // TODO verify if it helps the perf
-  fastify.decorateRequest(sessionKey, null)
-
-  if (!fastify.hasDecorator('decodeSecureSession')) {
-    fastify.decorate('decodeSecureSession', (cookie, log = fastify.log) => {
-      if (cookie === undefined) {
+  fastify.decorate('decodeSecureSession', (cookie, log = fastify.log, sessionKey = defaultSessionKey) => {
+    if (cookie === undefined) {
       // there is no cookie
-        log.trace('@fastify/secure-session: there is no cookie, creating an empty session')
-        return null
-      }
+      log.trace('@fastify/secure-session: there is no cookie, creating an empty session')
+      return null
+    }
 
-      // do not use destructuring or it will deopt
-      const split = cookie.split(';')
-      const cyphertextB64 = split[0]
-      const nonceB64 = split[1]
+    if (!sessionKeys.has(sessionKey)) {
+      throw new Error('Unknown session key.')
+    }
 
-      if (split.length <= 1) {
+    const { key } = sessionKeys.get(sessionKey)
+
+    // do not use destructuring or it will deopt
+    const split = cookie.split(';')
+    const cyphertextB64 = split[0]
+    const nonceB64 = split[1]
+
+    if (split.length <= 1) {
       // the cookie is malformed
-        log.debug('@fastify/secure-session: the cookie is malformed, creating an empty session')
-        return null
-      }
+      log.debug('@fastify/secure-session: the cookie is malformed, creating an empty session')
+      return null
+    }
 
-      const cipher = Buffer.from(cyphertextB64, 'base64')
-      const nonce = Buffer.from(nonceB64, 'base64')
+    const cipher = Buffer.from(cyphertextB64, 'base64')
+    const nonce = Buffer.from(nonceB64, 'base64')
 
-      if (cipher.length < sodium.crypto_secretbox_MACBYTES) {
+    if (cipher.length < sodium.crypto_secretbox_MACBYTES) {
       // not long enough
-        log.debug('@fastify/secure-session: the cipher is not long enough, creating an empty session')
-        return null
-      }
+      log.debug('@fastify/secure-session: the cipher is not long enough, creating an empty session')
+      return null
+    }
 
-      if (nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
+    if (nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
       // the length is not correct
-        log.debug('@fastify/secure-session: the nonce does not have the required length, creating an empty session')
-        return null
-      }
+      log.debug('@fastify/secure-session: the nonce does not have the required length, creating an empty session')
+      return null
+    }
 
-      const msg = Buffer.allocUnsafe(cipher.length - sodium.crypto_secretbox_MACBYTES)
+    const msg = Buffer.allocUnsafe(cipher.length - sodium.crypto_secretbox_MACBYTES)
 
-      let signingKeyRotated = false
-      const decodeSuccess = key.some((k, i) => {
-        const decoded = sodium.crypto_secretbox_open_easy(msg, cipher, nonce, k)
+    let signingKeyRotated = false
+    const decodeSuccess = key.some((k, i) => {
+      const decoded = sodium.crypto_secretbox_open_easy(msg, cipher, nonce, k)
 
-        signingKeyRotated = decoded && i > 0
+      signingKeyRotated = decoded && i > 0
 
-        return decoded
-      })
+      return decoded
+    })
 
-      if (!decodeSuccess) {
+    if (!decodeSuccess) {
       // unable to decrypt
-        log.debug('@fastify/secure-session: unable to decrypt, creating an empty session')
-        return null
-      }
+      log.debug('@fastify/secure-session: unable to decrypt, creating an empty session')
+      return null
+    }
 
-      const session = new Proxy(new Session(JSON.parse(msg)), sessionProxyHandler)
-      session.changed = signingKeyRotated
-      return session
-    })
-  }
+    const session = new Proxy(new Session(JSON.parse(msg)), sessionProxyHandler)
+    session.changed = signingKeyRotated
+    return session
+  })
 
-  if (!fastify.hasDecorator('createSecureSession')) {
-    fastify.decorate('createSecureSession', (data) => new Proxy(new Session(data), sessionProxyHandler))
-  }
+  fastify.decorate('createSecureSession', (data) => new Proxy(new Session(data), sessionProxyHandler))
 
-  if (!fastify.hasDecorator('encodeSecureSession')) {
-    fastify.decorate('encodeSecureSession', (session) => {
-      const nonce = genNonce()
-      const msg = Buffer.from(JSON.stringify(session[kObj]))
+  fastify.decorate('encodeSecureSession', (session, sessionKey = defaultSessionKey) => {
+    if (!sessionKeys.has(sessionKey)) {
+      throw new Error('Unknown session key.')
+    }
 
-      const cipher = Buffer.allocUnsafe(msg.length + sodium.crypto_secretbox_MACBYTES)
-      sodium.crypto_secretbox_easy(cipher, msg, nonce, key[0])
+    const { key } = sessionKeys.get(sessionKey)
 
-      return cipher.toString('base64') + ';' + nonce.toString('base64')
-    })
-  }
+    const nonce = genNonce()
+    const msg = Buffer.from(JSON.stringify(session[kObj]))
+
+    const cipher = Buffer.allocUnsafe(msg.length + sodium.crypto_secretbox_MACBYTES)
+    sodium.crypto_secretbox_easy(cipher, msg, nonce, key[0])
+
+    return cipher.toString('base64') + ';' + nonce.toString('base64')
+  })
 
   if (fastify.hasPlugin('@fastify/cookie')) {
     fastify
@@ -192,41 +217,43 @@ function fastifySecureSession (fastify, options, next) {
     // the hooks must be registered after @fastify/cookie hooks
 
     fastify.addHook('onRequest', (request, reply, next) => {
-      const cookie = request.cookies[cookieName]
-      const result = fastify.decodeSecureSession(cookie, request.log)
+      for (const [sessionKey, { cookieName }] of sessionKeys.entries()) {
+        const cookie = request.cookies[cookieName]
+        const result = fastify.decodeSecureSession(cookie, request.log, sessionKey)
 
-      request[sessionKey] = new Proxy((result || new Session({})), sessionProxyHandler)
+        request[sessionKey] = new Proxy((result || new Session({})), sessionProxyHandler)
+      }
 
       next()
     })
 
     fastify.addHook('onSend', (request, reply, payload, next) => {
-      const session = request[sessionKey]
+      for (const [sessionKey, { cookieName, cookieOptions }] of sessionKeys.entries()) {
+        const session = request[sessionKey]
 
-      if (!session || !session.changed) {
+        if (!session || !session.changed) {
         // nothing to do
-        request.log.trace('@fastify/secure-session: there is no session or the session didn\'t change, leaving it as is')
-        next()
-        return
-      } else if (session.deleted) {
-        request.log.debug('@fastify/secure-session: deleting session')
-        const tmpCookieOptions = Object.assign(
-          {},
-          cookieOptions,
-          session[kCookieOptions],
-          { expires: new Date(0), maxAge: 0 }
-        )
-        reply.setCookie(cookieName, '', tmpCookieOptions)
-        next()
-        return
-      }
+          request.log.trace('@fastify/secure-session: there is no session or the session didn\'t change, leaving it as is')
+          continue
+        } else if (session.deleted) {
+          request.log.debug('@fastify/secure-session: deleting session')
+          const tmpCookieOptions = Object.assign(
+            {},
+            cookieOptions,
+            session[kCookieOptions],
+            { expires: new Date(0), maxAge: 0 }
+          )
+          reply.setCookie(cookieName, '', tmpCookieOptions)
+          continue
+        }
 
-      request.log.trace('@fastify/secure-session: setting session')
-      reply.setCookie(
-        cookieName,
-        fastify.encodeSecureSession(session),
-        Object.assign({}, cookieOptions, session[kCookieOptions])
-      )
+        request.log.trace('@fastify/secure-session: setting session')
+        reply.setCookie(
+          cookieName,
+          fastify.encodeSecureSession(session, sessionKey),
+          Object.assign({}, cookieOptions, session[kCookieOptions])
+        )
+      }
 
       next()
     })

--- a/test/decorators.js
+++ b/test/decorators.js
@@ -6,7 +6,7 @@ const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
 sodium.randombytes_buf(key)
 
 tap.test('it exposes encode and decode decorators for other libraries to use', async t => {
-  t.plan(8)
+  t.plan(10)
 
   const fastify = require('fastify')({
     logger: false
@@ -24,6 +24,9 @@ tap.test('it exposes encode and decode decorators for other libraries to use', a
   t.ok(fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' })))
   t.ok(fastify.encodeSecureSession(fastify.createSecureSession({})))
   t.not(fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' })), fastify.encodeSecureSession(fastify.createSecureSession({})))
+
+  t.throws(() => fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' }), 'key-does-not-exist'), {}, 'Unknown session key.')
+  t.throws(() => fastify.decodeSecureSession('bogus', undefined, 'key-does-not-exist'), {}, 'Unknown session key.')
 
   const cookie = fastify.encodeSecureSession(fastify.createSecureSession({ foo: 'bar' }))
   const decoded = fastify.decodeSecureSession(cookie)

--- a/test/fieldName.js
+++ b/test/fieldName.js
@@ -8,7 +8,7 @@ const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
 sodium.randombytes_buf(key)
 
 fastify.register(require('../'), {
-  fieldName: 'barfoo',
+  sessionKey: 'barfoo',
   cookieName: 'foobar',
   key
 })

--- a/test/fieldName.js
+++ b/test/fieldName.js
@@ -8,7 +8,7 @@ const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
 sodium.randombytes_buf(key)
 
 fastify.register(require('../'), {
-  sessionKey: 'barfoo',
+  sessionName: 'barfoo',
   cookieName: 'foobar',
   key
 })

--- a/test/fieldName.js
+++ b/test/fieldName.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')({ logger: false })
+const sodium = require('sodium-native')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+
+sodium.randombytes_buf(key)
+
+fastify.register(require('../'), {
+  fieldName: 'barfoo',
+  cookieName: 'foobar',
+  key
+})
+
+fastify.post('/', (request, reply) => {
+  request.barfoo.set('data', request.body)
+  reply.send('hello world')
+})
+
+t.teardown(fastify.close.bind(fastify))
+t.plan(6)
+
+fastify.get('/', (request, reply) => {
+  const data = request.barfoo.get('data')
+  if (!data) {
+    reply.code(404).send()
+    return
+  }
+  reply.send(data)
+})
+
+fastify.inject({
+  method: 'POST',
+  url: '/',
+  payload: {
+    some: 'data'
+  }
+}, (error, response) => {
+  t.error(error)
+  t.equal(response.statusCode, 200)
+  t.ok(response.headers['set-cookie'])
+  const { name } = response.cookies[0]
+  t.equal(name, 'foobar')
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      cookie: response.headers['set-cookie']
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.same(JSON.parse(response.payload), { some: 'data' })
+  })
+})

--- a/test/multi.js
+++ b/test/multi.js
@@ -14,7 +14,7 @@ fastify.register(SecureSession, {
     path: '/',
     maxAge: 3600
   },
-  fieldName: 'longTermSession'
+  sessionKey: 'longTermSession'
 })
 
 fastify.register(SecureSession, {
@@ -24,7 +24,7 @@ fastify.register(SecureSession, {
     path: '/',
     maxAge: 60
   },
-  fieldName: 'shortTermSession'
+  sessionKey: 'shortTermSession'
 })
 
 fastify.post('/', (request, reply) => {

--- a/test/multi.js
+++ b/test/multi.js
@@ -13,7 +13,7 @@ tap.test('it should handle multiple sessions properly', t => {
       path: '/',
       maxAge: 3600
     },
-    sessionKey: 'longTermSession'
+    sessionName: 'longTermSession'
   }, {
     secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     cookieName: 'short-term-cookie',
@@ -22,7 +22,7 @@ tap.test('it should handle multiple sessions properly', t => {
       maxAge: 60,
       domain: 'fastify.io'
     },
-    sessionKey: 'shortTermSession'
+    sessionName: 'shortTermSession'
   }])
 
   fastify.post('/', (request, reply) => {
@@ -106,11 +106,11 @@ tap.test('decorators should handle multiple sessions properly', async t => {
 
   await fastify.register(require('../'), [{
     secret: 'top_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    sessionKey: 'longTermSession'
+    sessionName: 'longTermSession'
   }, {
     secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     cookieName: 'short-term-cookie',
-    sessionKey: 'shortTermSession'
+    sessionName: 'shortTermSession'
   }])
 
   t.teardown(fastify.close.bind(fastify))

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')({ logger: false })
+const sodium = require('sodium-native')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+const SecureSession = require('../')
+
+sodium.randombytes_buf(key)
+
+fastify.register(SecureSession, {
+  secret: 'top_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  cookie: {
+    path: '/',
+    maxAge: 3600
+  },
+  fieldName: 'longTermSession'
+})
+
+fastify.register(SecureSession, {
+  secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  cookieName: 'short-term-cookie',
+  cookie: {
+    path: '/',
+    maxAge: 60
+  },
+  fieldName: 'shortTermSession'
+})
+
+fastify.post('/', (request, reply) => {
+  request.longTermSession.set('data', request.body)
+  request.shortTermSession.set('information', 'Lorem Ipsum')
+
+  reply.send('hello world')
+})
+
+t.teardown(fastify.close.bind(fastify))
+t.plan(8)
+
+fastify.get('/', (request, reply) => {
+  const data = request.longTermSession.get('data')
+  if (!data) {
+    reply.code(404).send()
+    return
+  }
+  reply.send(data)
+})
+
+fastify.inject({
+  method: 'POST',
+  url: '/',
+  payload: {
+    some: 'data'
+  }
+}, (error, response) => {
+  t.error(error)
+  t.equal(response.statusCode, 200)
+  t.ok(response.headers['set-cookie'])
+  t.equal(response.cookies.length, 2)
+  t.equal(response.cookies[0].name, 'longTermSession')
+  t.equal(response.cookies[1].name, 'short-term-cookie')
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      cookie: response.headers['set-cookie']
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.same(JSON.parse(response.payload), { some: 'data' })
+  })
+})

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,73 +1,134 @@
 'use strict'
 
-const t = require('tap')
-const fastify = require('fastify')({ logger: false })
-const sodium = require('sodium-native')
-const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
-const SecureSession = require('../')
+const tap = require('tap')
 
-sodium.randombytes_buf(key)
+tap.test('it should handle multiple sessions properly', t => {
+  const fastify = require('fastify')({
+    logger: false
+  })
 
-fastify.register(SecureSession, {
-  secret: 'top_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  cookie: {
-    path: '/',
-    maxAge: 3600
-  },
-  sessionKey: 'longTermSession'
-})
+  fastify.register(require('../'), [{
+    secret: 'top_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    cookie: {
+      path: '/',
+      maxAge: 3600
+    },
+    sessionKey: 'longTermSession'
+  }, {
+    secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    cookieName: 'short-term-cookie',
+    cookie: {
+      path: '/',
+      maxAge: 60,
+      domain: 'fastify.io'
+    },
+    sessionKey: 'shortTermSession'
+  }])
 
-fastify.register(SecureSession, {
-  secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  cookieName: 'short-term-cookie',
-  cookie: {
-    path: '/',
-    maxAge: 60
-  },
-  sessionKey: 'shortTermSession'
-})
+  fastify.post('/', (request, reply) => {
+    request.longTermSession.set('data', request.body)
+    request.shortTermSession.set('information', 'Lorem Ipsum')
 
-fastify.post('/', (request, reply) => {
-  request.longTermSession.set('data', request.body)
-  request.shortTermSession.set('information', 'Lorem Ipsum')
+    reply.send('hello world')
+  })
 
-  reply.send('hello world')
-})
+  fastify.post('/delete', (request, reply) => {
+    request.longTermSession.set('data', request.body)
+    request.shortTermSession.delete()
 
-t.teardown(fastify.close.bind(fastify))
-t.plan(8)
+    reply.send('hello world')
+  })
 
-fastify.get('/', (request, reply) => {
-  const data = request.longTermSession.get('data')
-  if (!data) {
-    reply.code(404).send()
-    return
-  }
-  reply.send(data)
-})
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(19)
 
-fastify.inject({
-  method: 'POST',
-  url: '/',
-  payload: {
-    some: 'data'
-  }
-}, (error, response) => {
-  t.error(error)
-  t.equal(response.statusCode, 200)
-  t.ok(response.headers['set-cookie'])
-  t.equal(response.cookies.length, 2)
-  t.equal(response.cookies[0].name, 'longTermSession')
-  t.equal(response.cookies[1].name, 'short-term-cookie')
+  fastify.get('/', (request, reply) => {
+    const data = request.longTermSession.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
 
   fastify.inject({
-    method: 'GET',
+    method: 'POST',
     url: '/',
-    headers: {
-      cookie: response.headers['set-cookie']
+    payload: {
+      some: 'data'
     }
   }, (error, response) => {
     t.error(error)
-    t.same(JSON.parse(response.payload), { some: 'data' })
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    t.equal(response.cookies.length, 2)
+    t.equal(response.cookies[0].name, 'longTermSession')
+    t.equal(response.cookies[0].maxAge, 3600)
+    t.equal(response.cookies[0].domain, undefined)
+
+    t.equal(response.cookies[1].name, 'short-term-cookie')
+    t.equal(response.cookies[1].maxAge, 60)
+    t.equal(response.cookies[1].domain, 'fastify.io')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+    })
   })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/delete',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    t.equal(response.cookies.length, 2)
+    t.equal(response.cookies[0].name, 'longTermSession')
+    t.equal(response.cookies[1].name, 'short-term-cookie')
+    t.equal(response.cookies[1].maxAge, 0)
+  })
+})
+
+tap.test('decorators should handle multiple sessions properly', async t => {
+  const fastify = require('fastify')({
+    logger: false
+  })
+
+  await fastify.register(require('../'), [{
+    secret: 'top_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    sessionKey: 'longTermSession'
+  }, {
+    secret: 'VS-nfD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    cookieName: 'short-term-cookie',
+    sessionKey: 'shortTermSession'
+  }])
+
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(5)
+
+  t.ok(fastify.encodeSecureSession(fastify.createSecureSession({}), 'shortTermSession'))
+
+  const shortTermSession = fastify.createSecureSession({ foo: 'bar' })
+  const longTermSession = fastify.createSecureSession({ bar: 'foo' })
+  const shortTermSessionEncoded = fastify.encodeSecureSession(shortTermSession, 'shortTermSession')
+  const longTermSessionEncoded = fastify.encodeSecureSession(longTermSession, 'longTermSession')
+
+  t.ok(fastify.decodeSecureSession(longTermSessionEncoded, undefined, 'longTermSession'))
+  t.equal(fastify.decodeSecureSession(longTermSessionEncoded, undefined, 'shortTermSession'), null)
+
+  const decodedLongTermSession = fastify.decodeSecureSession(longTermSessionEncoded, undefined, 'longTermSession')
+  t.equal(decodedLongTermSession.get('bar'), 'foo')
+
+  const decodedShortTermSession = fastify.decodeSecureSession(shortTermSessionEncoded, undefined, 'shortTermSession')
+  t.equal(decodedShortTermSession.get('foo'), 'bar')
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,8 +5,8 @@ import { FastifyPluginCallback, FastifyBaseLogger } from "fastify";
 declare module "fastify" {
   interface FastifyInstance {
     createSecureSession(data?: Record<string, any>): fastifySecureSession.Session
-    decodeSecureSession(cookie: string, log?: FastifyBaseLogger, sessionKey?: string): fastifySecureSession.Session | null
-    encodeSecureSession(session: fastifySecureSession.Session, sessionKey?: string): string
+    decodeSecureSession(cookie: string, log?: FastifyBaseLogger, sessionName?: string): fastifySecureSession.Session | null
+    encodeSecureSession(session: fastifySecureSession.Session, sessionName?: string): string
   }
 
   interface FastifyRequest {
@@ -14,7 +14,7 @@ declare module "fastify" {
   }
 }
 
-type FastifySecureSession = FastifyPluginCallback<fastifySecureSession.SecureSessionPluginOptions | (fastifySecureSession.SecureSessionPluginOptions & Required<Pick<fastifySecureSession.SecureSessionPluginOptions, 'sessionKey'>>)[]>;
+type FastifySecureSession = FastifyPluginCallback<fastifySecureSession.SecureSessionPluginOptions | (fastifySecureSession.SecureSessionPluginOptions & Required<Pick<fastifySecureSession.SecureSessionPluginOptions, 'sessionName'>>)[]>;
 
 declare namespace fastifySecureSession {
   export type Session<T = SessionData> = Partial<T> & {
@@ -35,7 +35,7 @@ declare namespace fastifySecureSession {
   export type SecureSessionPluginOptions = {
     cookie?: CookieSerializeOptions
     cookieName?: string
-    sessionKey?: string
+    sessionName?: string
   } & ({ key: string | Buffer | (string | Buffer)[] } | {
     secret: string | Buffer,
     salt: string | Buffer

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,9 +20,10 @@ declare namespace fastifySecureSession {
   export type Session<T = SessionData> = Partial<T> & {
     changed: boolean;
     deleted: boolean;
-    get<Key extends keyof SessionData>(key: Key): SessionData[Key] | undefined;
-    set<Key extends keyof SessionData>(key: Key, value: SessionData[Key] | undefined): void;
-    data(): SessionData | undefined;
+    get<Key extends keyof T>(key: Key): T[Key] | undefined;
+    get(key: string): any | undefined;
+    set<Key extends keyof T>(key: Key, value: T[Key] | undefined): void;
+    data(): T | undefined;
     delete(): void;
     options(opts: CookieSerializeOptions): void;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ declare namespace fastifySecureSession {
   export type SecureSessionPluginOptions = {
     cookie?: CookieSerializeOptions
     cookieName?: string
-    fieldName?: string
+    sessionKey?: string
   } & ({ key: string | Buffer | (string | Buffer)[] } | {
     secret: string | Buffer,
     salt: string | Buffer

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,8 +5,8 @@ import { FastifyPluginCallback, FastifyBaseLogger } from "fastify";
 declare module "fastify" {
   interface FastifyInstance {
     createSecureSession(data?: Record<string, any>): fastifySecureSession.Session
-    decodeSecureSession(cookie: string, log?: FastifyBaseLogger): fastifySecureSession.Session | null
-    encodeSecureSession(session: fastifySecureSession.Session): string
+    decodeSecureSession(cookie: string, log?: FastifyBaseLogger, sessionKey?: string): fastifySecureSession.Session | null
+    encodeSecureSession(session: fastifySecureSession.Session, sessionKey?: string): string
   }
 
   interface FastifyRequest {
@@ -14,7 +14,7 @@ declare module "fastify" {
   }
 }
 
-type FastifySecureSession = FastifyPluginCallback<fastifySecureSession.SecureSessionPluginOptions>;
+type FastifySecureSession = FastifyPluginCallback<fastifySecureSession.SecureSessionPluginOptions | (fastifySecureSession.SecureSessionPluginOptions & Required<Pick<fastifySecureSession.SecureSessionPluginOptions, 'sessionKey'>>)[]>;
 
 declare namespace fastifySecureSession {
   export type Session<T = SessionData> = Partial<T> & {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare module "fastify" {
 type FastifySecureSession = FastifyPluginCallback<fastifySecureSession.SecureSessionPluginOptions>;
 
 declare namespace fastifySecureSession {
-  export type Session = Partial<SessionData> & {
+  export type Session<T = SessionData> = Partial<T> & {
     changed: boolean;
     deleted: boolean;
     get<Key extends keyof SessionData>(key: Key): SessionData[Key] | undefined;
@@ -34,6 +34,7 @@ declare namespace fastifySecureSession {
   export type SecureSessionPluginOptions = {
     cookie?: CookieSerializeOptions
     cookieName?: string
+    fieldName?: string
   } & ({ key: string | Buffer | (string | Buffer)[] } | {
     secret: string | Buffer,
     salt: string | Buffer

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,7 +12,7 @@ app.register(SecureSessionPlugin, { key: "foobar" });
 app.register(SecureSessionPlugin, { key: Buffer.from("foo") });
 app.register(SecureSessionPlugin, { key: ["foo", "bar"] });
 app.register(SecureSessionPlugin, { secret: "foo", salt: "bar" });
-app.register(SecureSessionPlugin, { fieldName: "foo", key: "bar" });
+app.register(SecureSessionPlugin, { sessionKey: "foo", key: "bar" });
 
 declare module ".." {
   interface SessionData {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,8 +12,8 @@ app.register(SecureSessionPlugin, { key: "foobar" });
 app.register(SecureSessionPlugin, { key: Buffer.from("foo") });
 app.register(SecureSessionPlugin, { key: ["foo", "bar"] });
 app.register(SecureSessionPlugin, { secret: "foo", salt: "bar" });
-app.register(SecureSessionPlugin, { sessionKey: "foo", key: "bar" });
-app.register(SecureSessionPlugin, [{ sessionKey: "foo", key: "bar" }, { sessionKey: "bar", key: "bar" }]);
+app.register(SecureSessionPlugin, { sessionName: "foo", key: "bar" });
+app.register(SecureSessionPlugin, [{ sessionName: "foo", key: "bar" }, { sessionName: "bar", key: "bar" }]);
 
 declare module ".." {
   interface SessionData {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,10 +12,21 @@ app.register(SecureSessionPlugin, { key: "foobar" });
 app.register(SecureSessionPlugin, { key: Buffer.from("foo") });
 app.register(SecureSessionPlugin, { key: ["foo", "bar"] });
 app.register(SecureSessionPlugin, { secret: "foo", salt: "bar" });
+app.register(SecureSessionPlugin, { fieldName: "foo", key: "bar" });
 
 declare module ".." {
   interface SessionData {
     foo: string;
+  }
+}
+
+interface FooSessionData {
+  foo: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    foo: Session<FooSessionData>;
   }
 }
 
@@ -30,7 +41,13 @@ app.get("/not-websockets", async (request, reply) => {
   expectType<any>(request.session.baz);
   expectType<SessionData | undefined>(request.session.data());
   request.session.delete();
-  request.session.options({ maxAge: 42 });
+  request.session.options({ maxAge: 42 })
+
+  request.foo.set("foo", "bar");
+  expectType<string | undefined>(request.foo.get("foo"));
+  expectType<any>(request.foo.get("baz"));
+  request.foo.delete();
+  request.foo.options({ maxAge: 42 });
 });
 
 expectType<Session | null>(app.decodeSecureSession("some cookie"))

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -13,6 +13,7 @@ app.register(SecureSessionPlugin, { key: Buffer.from("foo") });
 app.register(SecureSessionPlugin, { key: ["foo", "bar"] });
 app.register(SecureSessionPlugin, { secret: "foo", salt: "bar" });
 app.register(SecureSessionPlugin, { sessionKey: "foo", key: "bar" });
+app.register(SecureSessionPlugin, [{ sessionKey: "foo", key: "bar" }, { sessionKey: "bar", key: "bar" }]);
 
 declare module ".." {
   interface SessionData {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Useful for #178 and #162. This PR is continuation of #163 by @Uzlopak which was closed because of conflicting decorators. In this PR it uses a different approach: it uses an array of options that each will create a session instead of registering the plugin multiple times. 

To use the decorators, you will have to pass the sessionKey so it selects the right key for decoding/encoding. To not introduce a breaking change, the first registered session will act as the default session.

It looks like a lot has changed, but that is mainly due to the introduction of the for-loops and indentation.

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
