### PR TITLE
chore: use isArray and isBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const sessionProxyHandler = {
 }
 
 function fastifySecureSession (fastify, options, next) {
-  if (!(options instanceof Array)) {
+  if (!Array.isArray(options)) {
     options = [options]
   }
 
@@ -83,19 +83,19 @@ function fastifySecureSession (fastify, options, next) {
       key = sessionOptions.key
       if (typeof key === 'string') {
         key = Buffer.from(key, 'base64')
-      } else if (key instanceof Array) {
+      } else if (Array.isArray(key)) {
         try {
           key = key.map(ensureBufferKey)
         } catch (error) {
           return next(error)
         }
-      } else if (!(key instanceof Buffer)) {
+      } else if (!Buffer.isBuffer(key)) {
         return next(new Error('key must be a string or a Buffer'))
       }
 
-      if (!(key instanceof Array) && isBufferKeyLengthInvalid(key)) {
+      if (!Array.isArray(key) && isBufferKeyLengthInvalid(key)) {
         return next(new Error(`key must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
-      } else if (key instanceof Array && key.every(isBufferKeyLengthInvalid)) {
+      } else if (Array.isArray(key) && key.every(isBufferKeyLengthInvalid)) {
         return next(new Error(`key lengths must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
       }
     }
@@ -104,7 +104,7 @@ function fastifySecureSession (fastify, options, next) {
       return next(new Error('key or secret must specified'))
     }
 
-    if (!(key instanceof Array)) {
+    if (!Array.isArray(key)) {
       key = [key]
     }
 
@@ -300,7 +300,7 @@ function genNonce () {
 }
 
 function ensureBufferKey (k) {
-  if (k instanceof Buffer) {
+  if (Buffer.isBuffer(k)) {
     return k
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Changed it to use `isArray` and `isBuffer` instead of `instanceof`.
I simply measured performance and found `isArray` is faster than `instanceof`.

- https://github.com/is2ei/perf_Node_isArray
- https://github.com/is2ei/perf_Node_isBuffer

Also, I think `isArray` and `isBuffer` are more readable.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
