### PR TITLE
pass the secret to fastify cookie if directly registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,9 @@ function fastifySecureSession (fastify, options, next) {
       .register(fp(addHooks))
   } else {
     fastify
-      .register(require('@fastify/cookie'))
+      .register(require('@fastify/cookie'), {
+        secret: options[0].secret
+      })
       .register(fp(addHooks))
   }
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function fastifySecureSession (fastify, options, next) {
   }
 
   let defaultSessionName
+  let defaultSecret
   const sessionNames = new Map()
 
   for (const sessionOptions of options) {
@@ -55,6 +56,10 @@ function fastifySecureSession (fastify, options, next) {
     if (sessionOptions.secret) {
       if (Buffer.byteLength(sessionOptions.secret) < 32) {
         return next(new Error('secret must be at least 32 bytes'))
+      }
+
+      if (!defaultSecret) {
+        defaultSecret = sessionOptions.secret
       }
 
       key = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
@@ -208,7 +213,7 @@ function fastifySecureSession (fastify, options, next) {
   } else {
     fastify
       .register(require('@fastify/cookie'), {
-        secret: options[0].secret
+        secret: defaultSecret
       })
       .register(fp(addHooks))
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes https://github.com/fastify/fastify-cookie/issues/227

I feel like this is a better solution than [238](https://github.com/fastify/fastify-cookie/pull/238) since it doesn't degrade security by silently not signing a cookie

Also, if fastify-cookie is manually registered before secure-session (in which case the user MUST pass a secret if they expect to sign their cookies afterward), it still throws indicating an incorrect usage

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
