### PR TITLE
add .touch() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ fastify.get('/', (request, reply) => {
   reply.send(data)
 })
 
+fastify.get('/ping', (request, reply) => {
+  request.session.options({maxAge: 3600})
+  
+  // Send the session cookie to the client even if the session data didn't change
+  // can be used to update cookie expiration
+  request.session.touch()
+  reply.send('pong')
+})
+
 fastify.post('/logout', (request, reply) => {
   request.session.delete()
   reply.send('logged out')

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ IMPORTANT: The new key you are trying to rotate to should always be the first ke
 ```js
 // first time running the app
 fastify.register(require('@fastify/secure-session'), {
-  key: [mySecureKey]
+  key: [mySecureKey],
 
   cookie: {
     path: '/'
@@ -228,7 +228,7 @@ do the following:
 ```js
 // first time running the app
 fastify.register(require('@fastify/secure-session'), {
-  key: [myNewKey, mySecureKey]
+  key: [myNewKey, mySecureKey],
 
   cookie: {
     path: '/'

--- a/index.js
+++ b/index.js
@@ -298,6 +298,10 @@ class Session {
   data () {
     return this[kObj]
   }
+
+  touch () {
+    this.changed = true
+  }
 }
 
 function genNonce () {

--- a/test/touch.js
+++ b/test/touch.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const tap = require('tap')
+const sodium = require('sodium-native')
+const cookie = require('cookie')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+sodium.randombytes_buf(key)
+
+tap.test('Sends cookies when touch is invoked and session data has not changed', async t => {
+  const maxAge = 3600
+  const fastify = require('fastify')({ logger: false })
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(8)
+
+  await fastify.register(require('../'), {
+    key,
+    cookie: {
+      path: '/',
+      maxAge
+    }
+  })
+
+  fastify.post('/login', (request, reply) => {
+    request.session.set('user', request.body.email)
+    reply.send('Welcome back!')
+  })
+
+  fastify.get('/ping', (request, reply) => {
+    request.session.touch()
+    reply.send('pong')
+  })
+
+  const loginResponse = await fastify.inject({
+    method: 'POST',
+    url: '/login',
+    payload: {
+      email: 'me@here.fine'
+    }
+  })
+
+  t.equal(loginResponse.statusCode, 200)
+  t.ok(loginResponse.headers['set-cookie'])
+  t.equal(cookie.parse(loginResponse.headers['set-cookie']).Path, '/')
+  t.equal(cookie.parse(loginResponse.headers['set-cookie'])['Max-Age'], `${maxAge}`)
+
+  const pingResponse = await fastify.inject({
+    method: 'GET',
+    url: '/ping'
+  })
+
+  t.equal(pingResponse.statusCode, 200)
+  t.ok(pingResponse.headers['set-cookie'])
+  t.equal(cookie.parse(loginResponse.headers['set-cookie']).Path, '/')
+  t.equal(cookie.parse(loginResponse.headers['set-cookie'])['Max-Age'], `${maxAge}`)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ declare namespace fastifySecureSession {
     data(): T | undefined;
     delete(): void;
     options(opts: CookieSerializeOptions): void;
+    touch(): void;
   }
 
   export interface SessionData {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -43,12 +43,14 @@ app.get("/not-websockets", async (request, reply) => {
   expectType<SessionData | undefined>(request.session.data());
   request.session.delete();
   request.session.options({ maxAge: 42 })
+  request.session.touch();
 
   request.foo.set("foo", "bar");
   expectType<string | undefined>(request.foo.get("foo"));
   expectType<any>(request.foo.get("baz"));
   request.foo.delete();
   request.foo.options({ maxAge: 42 });
+  request.foo.touch();
 });
 
 expectType<Session | null>(app.decodeSecureSession("some cookie"))


### PR DESCRIPTION
Implements feature request #197 

The `.touch()` method sets `changed=true` in order to send to cookie even when the session data has not changed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
