### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Then, register the plugin as follows:
 'use strict'
 
 const fastify = require('fastify')({ logger: false })
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 fastify.register(require('@fastify/secure-session'), {
   // the name of the attribute decorated on the request-object, defaults to 'session'
@@ -248,7 +248,7 @@ npx @fastify/secure-session > secret-key2
 ```
 
 ```js
-const fs = require('fs')
+const fs = require('node:fs')
 const fastify = require('fastify')({ logger: false })
 
 const key1 = fs.readFileSync(path.join(__dirname, 'secret-key1'))

--- a/examples/simple/example.js
+++ b/examples/simple/example.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const fastify = require('fastify')({ logger: false })
-const fs = require('fs')
-const path = require('path')
-const assert = require('assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const assert = require('node:assert')
 
 fastify.register(require('../..'), {
   key: fs.readFileSync(path.join(__dirname, 'example-key'))


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
