### PR TITLE
chore: replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ fastify.post('/logout', (request, reply) => {
 })
 ```
 
-If you enable [`debug` level logging](https://www.fastify.dev/docs/latest/Reference/Logging/),
+If you enable [`debug` level logging](https://fastify.dev/docs/latest/Reference/Logging/),
 you will see what steps the library is doing and understand why a session you
 expect to be there is not present. For extra details, you can also enable `trace`
 level logging.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ fastify.post('/logout', (request, reply) => {
 })
 ```
 
-If you enable [`debug` level logging](https://www.fastify.io/docs/latest/Reference/Logging/),
+If you enable [`debug` level logging](https://www.fastify.dev/docs/latest/Reference/Logging/),
 you will see what steps the library is doing and understand why a session you
 expect to be there is not present. For extra details, you can also enable `trace`
 level logging.

--- a/test/multi.js
+++ b/test/multi.js
@@ -20,7 +20,7 @@ tap.test('it should handle multiple sessions properly', t => {
     cookie: {
       path: '/',
       maxAge: 60,
-      domain: 'fastify.io'
+      domain: 'fastify.dev'
     },
     sessionName: 'shortTermSession'
   }])
@@ -68,7 +68,7 @@ tap.test('it should handle multiple sessions properly', t => {
 
     t.equal(response.cookies[1].name, 'short-term-cookie')
     t.equal(response.cookies[1].maxAge, 60)
-    t.equal(response.cookies[1].domain, 'fastify.io')
+    t.equal(response.cookies[1].domain, 'fastify.dev')
 
     fastify.inject({
       method: 'GET',


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
