### PR TITLE
Update the file name of the key in README.md for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx --yes @fastify/secure-session > secret-key
 If you don't want to use `npx`, you can still generate the `secret-key` installing the `@fastify/secure-session` library with your choice package manager, and then:
 
 ```sh
-./node_modules/@fastify/secure-session/genkey.js > secret_key
+./node_modules/@fastify/secure-session/genkey.js > secret-key
 ```
 
 Then, register the plugin as follows:


### PR DESCRIPTION
#### Overview

In README, the key file name is always `secret-key`. However, `secret_key` is used in the section.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
