### PR TITLE
Refine secret key handling for better flexibility and security

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,11 +103,15 @@ function fastifySecureSession (fastify, options, next) {
         return next(new Error(`key lengths must be ${sodium.crypto_secretbox_KEYBYTES} bytes`))
       }
 
+      const outputHash = Buffer.alloc(sodium.crypto_generichash_BYTES)
+
       if (Array.isArray(key)) {
-        defaultSecret = key[0].toString('hex')
+        sodium.crypto_generichash(outputHash, key[0])
       } else {
-        defaultSecret = key.toString('hex')
+        sodium.crypto_generichash(outputHash, key)
       }
+
+      defaultSecret = outputHash.toString('hex')
     }
 
     if (!key) {

--- a/test/key-rotation.js
+++ b/test/key-rotation.js
@@ -161,3 +161,169 @@ tap.test('does not support an empty key array', async t => {
 
   await t.rejects(() => fastify.after())
 })
+
+tap.test('signing works with only a string key array', function (t) {
+  const fastify = Fastify({ logger: false })
+
+  const key1 = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+  sodium.randombytes_buf(key1)
+
+  const key2 = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+  sodium.randombytes_buf(key2)
+
+  fastify.register(fastifySecureSession, {
+    key: [key1.toString('base64'), key2.toString('base64')]
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    reply.setCookie('my-session', JSON.stringify(request.body), {
+      httpOnly: true,
+      secure: true,
+      maxAge: 3600,
+      signed: true,
+      path: '/'
+    })
+    reply.send('session set')
+  })
+
+  fastify.get('/secure-session', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.get('/cookie-signed', (request, reply) => {
+    const data = request.unsignCookie(request.cookies['my-session'])
+    if (!data.valid) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data.value)
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(7)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+
+    const cookieHeader = response.headers['set-cookie'].join(';')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/secure-session',
+      headers: {
+        cookie: cookieHeader
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+
+      fastify.inject({
+        method: 'GET',
+        url: '/cookie-signed',
+        headers: {
+          cookie: cookieHeader
+        }
+      }, (error, response) => {
+        t.error(error)
+        t.same(JSON.parse(response.payload), { some: 'data' })
+      })
+    })
+  })
+})
+
+tap.test('signing works with only a buffer key array', function (t) {
+  const fastify = Fastify({ logger: false })
+
+  const key1 = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+  sodium.randombytes_buf(key1)
+
+  const key2 = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+  sodium.randombytes_buf(key2)
+
+  fastify.register(fastifySecureSession, {
+    key: [key1, key2]
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    reply.setCookie('my-session', JSON.stringify(request.body), {
+      httpOnly: true,
+      secure: true,
+      maxAge: 3600,
+      signed: true,
+      path: '/'
+    })
+    reply.send('session set')
+  })
+
+  fastify.get('/secure-session', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.get('/cookie-signed', (request, reply) => {
+    const data = request.unsignCookie(request.cookies['my-session'])
+    if (!data.valid) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data.value)
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(7)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+
+    const cookieHeader = response.headers['set-cookie'].join(';')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/secure-session',
+      headers: {
+        cookie: cookieHeader
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+
+      fastify.inject({
+        method: 'GET',
+        url: '/cookie-signed',
+        headers: {
+          cookie: cookieHeader
+        }
+      }, (error, response) => {
+        t.error(error)
+        t.same(JSON.parse(response.payload), { some: 'data' })
+      })
+    })
+  })
+})

--- a/test/key.js
+++ b/test/key.js
@@ -135,3 +135,83 @@ tap.test('does not support key length greater than sodium "crypto_secretbox_KEYB
 
   await t.rejects(() => fastify.after())
 })
+
+tap.test('signing works with only a key', function (t) {
+  const fastify = Fastify({ logger: false })
+  const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+
+  sodium.randombytes_buf(key)
+
+  fastify.register(fastifySecureSession, {
+    key
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    reply.setCookie('my-session', JSON.stringify(request.body), {
+      httpOnly: true,
+      secure: true,
+      maxAge: 3600,
+      signed: true,
+      path: '/'
+    })
+    reply.send('session set')
+  })
+
+  fastify.get('/secure-session', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.get('/cookie-signed', (request, reply) => {
+    const data = request.unsignCookie(request.cookies['my-session'])
+    if (!data.valid) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data.value)
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+  t.plan(7)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+
+    const cookieHeader = response.headers['set-cookie'].join(';')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/secure-session',
+      headers: {
+        cookie: cookieHeader
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+
+      fastify.inject({
+        method: 'GET',
+        url: '/cookie-signed',
+        headers: {
+          cookie: cookieHeader
+        }
+      }, (error, response) => {
+        t.error(error)
+        t.same(JSON.parse(response.payload), { some: 'data' })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Changes

The ```@fastify/secure-session``` plugin emphasizes using a pregenerated key. Before these code changes, you could not use signed sessions / cookies, when only using a key. When using a key and a secret, it was confusing which of the two is used for what?

After this commit, signing will work with only a key or an array of keys, without the need of a secret. When setting a key, the key is used for the session key and also for the cookie secret. When setting a key and a secret, the secret is not used. When using a secret only, this will be used for the session key and the cookie secret.

- key -> key = session key & cookie secret
- key & secret -> key = session key & cookie secret, secret is ignored
- secret -> secret = session key & cookie secret

I used ```sodium.crypto_generichash(outputHash, key)``` (or ```sodium.crypto_generichash(outputHash, key[0])``` if you used key rotation) to convert the buffer to a string that we can use for cookie secret. This should give us a secure enough string and make sure key is not the same as secret.

This pull request fixes issue #77.

## Unit tests

I added 3 unit tests which would fail using the old code:
- _'signing works with only a key'_ in ```key.js```
- _'signing works with only a string key array'_ in ```key-rotation.js```
- _'signing works with only a buffer key array'_ in ```key-rotation.js```

## Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)