### PR TITLE
deps: downgrade sodium-native dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@fastify/cookie": "^11.0.1",
     "fastify-plugin": "^5.0.0",
-    "sodium-native": "^4.0.10"
+    "sodium-native": "4.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
sodium-native breaks linux installation starting from the "4.2.1"
https://github.com/holepunchto/sodium-native/issues/202

The latest version "4.3.1" is also broken.

The types tests are also failing in the main branch.