### PR TITLE
fix: do not assume that supplied string is base64

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function fastifySecureSession (fastify, options, next) {
     if (sessionOptions.key) {
       key = sessionOptions.key
       if (typeof key === 'string') {
-        key = Buffer.from(key, 'base64')
+        key = Buffer.from(key, 'ascii')
       } else if (Array.isArray(key)) {
         try {
           key = key.map(ensureBufferKey)


### PR DESCRIPTION
- currently, if keys of type "string" are supplied. Then, the script assumes that it is "base64" encoded which is likely not true.

```
key = Buffer.from(key, 'base64')
```

- usually the user is supplying an `ascii` string generated securely.

- there is strong case, why user might prefer to generate `ascii` secret instead of `bytes`, for example the user might want to load secret through environment variable

- therefore, support for `ascii` strings is important

Security implications:

- a buffer is 8 bits is javascript[1], hence it can store 256 values
- `ascii` strings are also (8 bits i.e. 1 byte), however only 95 of them are printable[2]

Therefore, an attacker who is trying to brute force would have to guess 256 possible values for `Buffer`. But with `ascii`, brute forcing over only `95` characters is required.

[1]: https://nodejs.org/api/buffer.html#buffer
[2]: https://www.ascii-code.com/characters/printable-characters

fixes: #274

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
