### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "contributors": [
     {
       "name": "Tomas Della Vedova",
-      "url": "http://delved.org"
+      "url": "https://delvedor.dev"
     },
     {
       "name": "James Sumners",


### PR DESCRIPTION
Old link no longer exists